### PR TITLE
Add meal planning

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,6 +15,13 @@ frontend build step. Target HA: 2026.4+.
   `RestoreEntity` for persistence across restarts.
 - Coordinator-driven refresh; per-tick housekeeping (e.g. trash chore
   auto-completion) runs on coordinator refresh, not separate timers.
+- **Options-flow ↔ YAML import contract.** YAML is re-imported on every HA
+  start via `async_step_import` → `_normalize_options`. Any new options-flow
+  key (set only via the UI) **must** be either listed in `_normalize_options`
+  or carried over from the existing entry's options, otherwise it gets wiped
+  on the next restart. When adding a new options key, update both
+  `schemas.OPTIONS_SCHEMA` and `_normalize_options` (the `existing=` merge
+  branch) together.
 
 ## Config schema (HA `configuration.yaml`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Visual editors for every FamilyBoard custom card
+  (`progress`, `chores`, `calendar`, `filter`, `view`). Each card now
+  exposes `getConfigElement()`/`getStubConfig()` returning a tiny
+  `ha-form`-driven editor, so the dashboard card picker no longer
+  shows "Visuele editor niet ondersteund". Schema covers the keys the
+  cards already read; dict-typed options (`colors`, `names`,
+  `filter_map`, `shared_calendars`, `member_entities`, `icons`,
+  `extra_chips`) remain YAML-only.
+- New `custom:familyboard-view-card` Lovelace card that renders chip
+  selectors for any FamilyBoard `select` entity (default
+  `select.familyboard_view`). Labels are pulled from Home Assistant
+  state translations via `hass.formatEntityState`, so adding a new
+  language only requires updating `translations/<lang>.json`.
+- Stable English option keys for `select.familyboard_view`
+  (`today`/`tomorrow`/`week`/`two_weeks`/`month`) and
+  `select.familyboard_layout` (`list`/`agenda`). Existing
+  installations with restored Dutch states are migrated
+  automatically. User-visible labels are now driven by the new
+  `entity.select.{view,layout}.state.*` translation blocks.
 - Meal planning Phase 1: optional `meal_calendar` config key, new
   `sensor.familyboard_meals` exposing tonight's meal and a 7-day week
-  attribute, plus a "Vanavond" + week-strip + "Maaltijd toevoegen"
+  attribute, plus a "Vanavond" + week-strip + "Maaltijd plannen"
   block in the dashboard.
-- Auto-seeded **FamilyBoard** sidebar dashboard. The integration now
-  creates a storage-mode Lovelace dashboard at `/familyboard` on first
-  startup, rendered via the `custom:familyboard` strategy. Users can
-  edit the dashboard freely afterwards; the seed only runs when no
-  dashboard with that URL path exists.
+- Meal placeholders: titles `-`, `--`, `?`, `geen`, `none`, `n/a`
+  (case-insensitive) mark a day as deliberately skipped. They render
+  as 🚫 on the board and do not trigger the unplanned-meal alert.
+- New `binary_sensor.familyboard_meals_unplanned` (device class
+  `problem`) is on whenever any of the next 7 days has no meal entry
+  at all (skipped placeholders count as planned). Attributes expose
+  `unplanned_dates`, `count`, and `next_unplanned` so users can wire
+  their own automation/notifications.
+- Meal planning Phase 2: new `sensor.familyboard_recent_meals` scoring
+  the last 90 days of meal events (`uses − recency_penalty`,
+  capped at 12 distinct titles) and a Bubble Card pop-up
+  (`#meal-picker`) on the dashboard that lists the top picks as
+  tappable buttons creating an all-day event for today on the
+  meals calendar.
 - Dev container (`.devcontainer.json`) plus `scripts/setup`,
   `scripts/develop`, `scripts/lint`, `requirements-dev.txt` and a
   minimal `config/configuration.yaml` for running a local Home
@@ -27,6 +55,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   equivalent under debugpy) and `pytest` on the current file.
 
 ### Changed
+- Dashboards (`familyboard.yaml`, `tasks.yaml`) and the
+  `familyboard-strategy` no longer hand-build view-chip
+  `mushroom-chips-card` blocks; they delegate to the new
+  `custom:familyboard-view-card`.
+- Card console banners now report `<manifest-version>-<short-hash>`
+  instead of a hardcoded string, sourced from `manifest.json` at
+  resource-registration time.
 - `familyboard-filter-card` now styles selection state via `card-mod`'s
   `mushroom-chip$` selector targeting the inner `.chip` element. The
   previous `:host`/`ha-card` selector never painted because the chip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Meal planning Phase 1: optional `meal_calendar` config key, new
+  `sensor.familyboard_meals` exposing tonight's meal and a 7-day week
+  attribute, plus a "Vanavond" + week-strip + "Maaltijd toevoegen"
+  block in the dashboard.
+
 ## [0.1.0] - 2026-04-20
 
 Initial tracked release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **FR-12 Event countdown**: new `text.familyboard_countdown_label`
+  and `datetime.familyboard_countdown_date` entities and a
+  `custom:familyboard-countdown-card` Lovelace card. The card shows
+  "⏳ Nog N dagen tot LABEL!", "⏳ Morgen is het LABEL!" or
+  "🎉 Vandaag is het LABEL!", hides itself when no label is set,
+  and auto-clears the label one tick after the date passes. Tap the
+  gear icon to edit label + date directly on the kiosk (no admin
+  login needed).
 - Visual editors for every FamilyBoard custom card
   (`progress`, `chores`, `calendar`, `filter`, `view`). Each card now
   exposes `getConfigElement()`/`getStubConfig()` returning a tiny

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ a unified family dashboard with reusable Lovelace cards.
 - **Chores sensor** — combined per-member list of `todo.*` items, sorted overdue → upcoming → no-date, optionally cross-matched with calendar tasks for start/end times.
 - **Per-member progress sensor** — daily completion tracking with color rings.
 - **Interactive snooze reminders** — actionable mobile_app notifications scheduled at task start time, with persistence across HA restarts and away-aware delivery.
-- **Custom Lovelace cards** — composable building blocks: `chores`, `calendar`, `filter`, `progress`. Each takes its own config; users can mix them into any dashboard.
+- **Custom Lovelace cards** — composable building blocks: `chores`, `calendar`, `filter`, `progress`, `countdown`. Each takes its own config; users can mix them into any dashboard.
 - **Add-event form entities** — built-in `select`, `text`, `switch` and `datetime` entities power a "create event" form with cascading member → calendar pickers.
+- **Event countdown** — kiosk-editable countdown to a single target date (label + date), rendered by `custom:familyboard-countdown-card`. Auto-hides when no label is set and self-clears the day after the event.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ familyboard:
     - entity: todo.groceries
       members: [Person_1, Person_2]
       name: Groceries
+  meal_calendar: calendar.meals
 ```
 
 ### Member options

--- a/README.md
+++ b/README.md
@@ -168,6 +168,40 @@ familyboard:
 | `sensor.familyboard_members` | Member metadata for cards |
 | `sensor.familyboard_progress` | Per-member daily completion progress |
 | `sensor.familyboard_compliment` | Time-of-day greeting |
+| `sensor.familyboard_meals` | Tonight's meal + 7-day week strip (requires `meal_calendar`) |
+| `sensor.familyboard_recent_meals` | Top recent meal titles scored by usage and recency for the quick picker |
+| `binary_sensor.familyboard_meals_unplanned` | `on` when any of the next 7 days has no meal entry; placeholders count as planned |
+
+#### Meal placeholders
+
+If you want a day to count as "planned" without specifying a real meal
+(eating out, leftovers, skip), create the calendar event with one of
+these titles (case-insensitive): `-`, `--`, `?`, `geen`, `none`,
+`n/a`. The board renders 🚫 for that day and the
+`binary_sensor.familyboard_meals_unplanned` stays off.
+
+#### Example automation — alert when next week has gaps
+
+```yaml
+automation:
+  - alias: "Maaltijden plannen reminder"
+    trigger:
+      - platform: time
+        at: "18:00:00"
+    condition:
+      - condition: state
+        entity_id: binary_sensor.familyboard_meals_unplanned
+        state: "on"
+    action:
+      - service: notify.mobile_app_phone
+        data:
+          title: "Plan de maaltijden"
+          message: >-
+            {{ state_attr('binary_sensor.familyboard_meals_unplanned',
+            'count') }} dagen zonder maaltijd — eerstvolgende:
+            {{ state_attr('binary_sensor.familyboard_meals_unplanned',
+            'next_unplanned') }}.
+```
 
 ### Controls (form / filter)
 

--- a/custom_components/familyboard/__init__.py
+++ b/custom_components/familyboard/__init__.py
@@ -75,6 +75,7 @@ _FRONTEND_RESOURCES: list[tuple[str, str]] = [
     ("familyboard_view_card", "familyboard-view-card.js"),
     ("familyboard_calendar_card", "familyboard-calendar-card.js"),
     ("familyboard_progress_card", "familyboard-progress-card.js"),
+    ("familyboard_countdown_card", "familyboard-countdown-card.js"),
     ("familyboard_strategy", "familyboard-strategy.js"),
 ]
 
@@ -88,6 +89,7 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 ADD_EVENT_SCHEMA = vol.Schema({})
+ADD_MEAL_SCHEMA = vol.Schema({})
 SNOOZE_TEST_SCHEMA = vol.Schema({vol.Required("uid"): cv.string})
 CANCEL_REMINDER_SCHEMA = vol.Schema({vol.Required("uid"): cv.string})
 
@@ -218,7 +220,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if trash_chore_manager is not None:
         await trash_chore_manager.async_stop()
 
-    for svc in ("add_event", "snooze_test", "cancel_reminder"):
+    for svc in ("add_event", "add_meal", "snooze_test", "cancel_reminder"):
         if hass.services.has_service(DOMAIN, svc):
             hass.services.async_remove(DOMAIN, svc)
 
@@ -477,6 +479,66 @@ def _async_register_services(hass: HomeAssistant, conf: dict) -> None:
             blocking=True,
         )
 
+    async def handle_add_meal(call: ServiceCall) -> None:
+        """Create an all-day meal event from the title + day_start entities.
+
+        Reads ``text.familyboard_event_title`` (title) and
+        ``datetime.familyboard_day_start`` (date) and writes an all-day
+        event into the configured ``meal_calendar``. Resets the title
+        afterwards. No service data required at the call site, so it can be
+        triggered from a Mushroom chip / Bubble button without touching
+        Jinja-in-data limitations.
+        """
+        meal_calendar = conf.get("meal_calendar")
+        if not meal_calendar:
+            raise HomeAssistantError(
+                "meal_calendar is not configured in FamilyBoard options"
+            )
+
+        title = hass.states.get(EVENT_TITLE_ENTITY)
+        day_start = hass.states.get(DAY_START_ENTITY)
+        if not title or not day_start:
+            raise HomeAssistantError("Missing entity states for add_meal")
+
+        event_title = title.state
+        if not event_title or event_title in ("unknown", "unavailable"):
+            _LOGGER.debug("Empty meal title; skipping add_meal")
+            return
+
+        try:
+            start_date = _dt.fromisoformat(day_start.state).date()
+        except (ValueError, TypeError) as err:
+            raise HomeAssistantError(
+                f"Invalid day_start datetime: {day_start.state}"
+            ) from err
+
+        end_date = start_date + timedelta(days=1)
+
+        await hass.services.async_call(
+            "calendar",
+            "create_event",
+            {
+                "summary": event_title,
+                "start_date": start_date.isoformat(),
+                "end_date": end_date.isoformat(),
+            },
+            target={"entity_id": meal_calendar},
+            blocking=True,
+        )
+
+        await hass.services.async_call(
+            "text",
+            "set_value",
+            {"entity_id": EVENT_TITLE_ENTITY, "value": ""},
+            blocking=True,
+        )
+
+        # Refresh the meals sensor immediately so the dashboard reflects
+        # the new event without waiting for the 5-minute coordinator tick.
+        coordinator = hass.data.get(DOMAIN, {}).get("coordinator")
+        if coordinator is not None:
+            await coordinator.async_request_refresh()
+
     async def handle_snooze_test(call: ServiceCall) -> None:
         """Force-fire a reminder by uid for testing."""
         manager: ReminderManager | None = hass.data.get(DOMAIN, {}).get(
@@ -499,6 +561,9 @@ def _async_register_services(hass: HomeAssistant, conf: dict) -> None:
 
     hass.services.async_register(
         DOMAIN, "add_event", handle_add_event, schema=ADD_EVENT_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, "add_meal", handle_add_meal, schema=ADD_MEAL_SCHEMA
     )
     hass.services.async_register(
         DOMAIN, "snooze_test", handle_snooze_test, schema=SNOOZE_TEST_SCHEMA

--- a/custom_components/familyboard/__init__.py
+++ b/custom_components/familyboard/__init__.py
@@ -45,6 +45,7 @@ from .const import (
     EVENT_MEMBER_ENTITY,
     EVENT_START_ENTITY,
     EVENT_TITLE_ENTITY,
+    MEAL_LOOKAHEAD_DAYS,
     SCAN_INTERVAL_MINUTES,
     TASK_IDENTIFIER,
     VIEW_ENTITY,
@@ -886,4 +887,49 @@ class FamilyBoardCoordinator(DataUpdateCoordinator):
             except HomeAssistantError:
                 _LOGGER.exception("Reminder sync failed")
 
+        result["meals"] = await self._fetch_meals(now)
+
         return result
+
+    async def _fetch_meals(self, now: _dt) -> list[dict]:
+        """Fetch upcoming meals from the configured ``meal_calendar``.
+
+        Returns a list of ``{date, title, start, end, description, uid,
+        all_day}`` ordered by start. Empty list when no meal calendar is
+        configured or the calendar entity yields nothing.
+        """
+        meal_entity = self.conf.get("meal_calendar")
+        if not meal_entity:
+            return []
+
+        today = now.date()
+        window_start = _dt.combine(today, time.min, tzinfo=now.tzinfo)
+        window_end = _dt.combine(
+            today + timedelta(days=MEAL_LOOKAHEAD_DAYS),
+            time.max,
+            tzinfo=now.tzinfo,
+        )
+        events = await self._fetch_events(
+            meal_entity, window_start.isoformat(), window_end.isoformat()
+        )
+
+        meals: list[dict] = []
+        for ev in events:
+            start = ev.get("start") or ""
+            end = ev.get("end") or ""
+            date = start[:10] if start else ""
+            if not date:
+                continue
+            meals.append(
+                {
+                    "date": date,
+                    "title": ev.get("summary", ""),
+                    "start": start,
+                    "end": end,
+                    "description": ev.get("description", ""),
+                    "uid": ev.get("uid", ""),
+                    "all_day": "T" not in start,
+                }
+            )
+        meals.sort(key=lambda m: m["start"])
+        return meals

--- a/custom_components/familyboard/__init__.py
+++ b/custom_components/familyboard/__init__.py
@@ -46,11 +46,12 @@ from .const import (
     EVENT_START_ENTITY,
     EVENT_TITLE_ENTITY,
     MEAL_LOOKAHEAD_DAYS,
+    MEAL_RECENT_WINDOW_DAYS,
     SCAN_INTERVAL_MINUTES,
     TASK_IDENTIFIER,
     VIEW_ENTITY,
 )
-from .helpers import member_calendar_entities
+from .helpers import is_meal_placeholder, member_calendar_entities, score_recent_meals
 from .reminder import ReminderManager
 from .schemas import OPTIONS_SCHEMA, default_options
 from .trash import TrashChoreManager
@@ -58,6 +59,7 @@ from .trash import TrashChoreManager
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [
+    Platform.BINARY_SENSOR,
     Platform.CALENDAR,
     Platform.SENSOR,
     Platform.SELECT,
@@ -70,6 +72,7 @@ PLATFORMS: list[Platform] = [
 _FRONTEND_RESOURCES: list[tuple[str, str]] = [
     ("familyboard_card", "familyboard-chores-card.js"),
     ("familyboard_filter_card", "familyboard-filter-card.js"),
+    ("familyboard_view_card", "familyboard-view-card.js"),
     ("familyboard_calendar_card", "familyboard-calendar-card.js"),
     ("familyboard_progress_card", "familyboard-progress-card.js"),
     ("familyboard_strategy", "familyboard-strategy.js"),
@@ -183,7 +186,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def _async_startup(_event: Any = None) -> None:
         """Run frontend + entity wiring + initial refresh once HA is ready."""
         await _async_register_frontend(hass)
-        await _async_seed_dashboard(hass)
         await _async_link_entities(hass, entry)
         await reminder_manager.async_start()
         await trash_chore_manager.async_start()
@@ -233,25 +235,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def _async_link_entities(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Ensure all FB entities are linked to our device + this entry.
-
-    Also migrates entity_ids that earlier versions generated from
-    translation_key (e.g. ``select.familyboard_calendar_filter``) to the
-    canonical ids the dashboard / frontend cards reference (e.g.
-    ``select.familyboard_calendar``).
-    """
+    """Ensure all FB entities are linked to our device + this entry."""
     dev_reg = dr.async_get(hass)
     device = dev_reg.async_get_device(identifiers={DEVICE_IDENTIFIER})
     if device is None:
         return
-
-    # unique_id -> desired entity_id for entities where we pin an object_id.
-    canonical_ids: dict[str, str] = {
-        "familyboard_calendar": "select.familyboard_calendar",
-        "familyboard_view": "select.familyboard_view",
-        "familyboard_layout": "select.familyboard_layout",
-        "familyboard_event_member": "select.familyboard_event_member",
-    }
 
     ent_reg = er.async_get(hass)
     for ent in list(ent_reg.entities.values()):
@@ -265,13 +253,6 @@ async def _async_link_entities(hass: HomeAssistant, entry: ConfigEntry) -> None:
         if updates:
             ent_reg.async_update_entity(ent.entity_id, **updates)
 
-        desired = canonical_ids.get(ent.unique_id)
-        if desired and ent.entity_id != desired and ent_reg.async_get(desired) is None:
-            _LOGGER.info(
-                "Migrating FamilyBoard entity_id %s -> %s", ent.entity_id, desired
-            )
-            ent_reg.async_update_entity(ent.entity_id, new_entity_id=desired)
-
 
 # ---------------------------------------------------------------------------
 # Frontend resource registration (Lovelace)
@@ -279,14 +260,39 @@ async def _async_link_entities(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
 
 def _get_js_version(filename: str) -> str:
-    """Return a short SHA256-based version hash for cache busting."""
+    """Return ``<manifest-version>-<short-hash>`` for cache busting.
+
+    The manifest version is exposed to cards via ``import.meta.url``'s ``?v=``
+    query parameter so each card can print its actual version in console.info
+    without a build step.
+    """
     js_path = Path(__file__).parent / "frontend" / filename
     try:
         content = js_path.read_bytes()
     except OSError as err:
         _LOGGER.debug("Could not read %s for versioning: %s", js_path, err)
-        return "1"
-    return hashlib.sha256(content).hexdigest()[:8]
+        return _get_manifest_version()
+    short = hashlib.sha256(content).hexdigest()[:8]
+    return f"{_get_manifest_version()}-{short}"
+
+
+def _get_manifest_version() -> str:
+    """Return the integration version from manifest.json (cached)."""
+    cached = getattr(_get_manifest_version, "_cached", None)
+    if cached:
+        return cached
+    manifest_path = Path(__file__).parent / "manifest.json"
+    try:
+        import json
+
+        version = json.loads(manifest_path.read_text(encoding="utf-8")).get(
+            "version", "0.0.0"
+        )
+    except (OSError, ValueError) as err:
+        _LOGGER.debug("Could not read manifest version: %s", err)
+        version = "0.0.0"
+    _get_manifest_version._cached = version  # type: ignore[attr-defined]
+    return version
 
 
 async def _async_register_frontend(hass: HomeAssistant) -> None:
@@ -347,112 +353,9 @@ async def _async_sync_lovelace_resources(hass: HomeAssistant) -> None:
             )
 
 
-_DASHBOARD_URL_PATH = "familyboard"
-_DASHBOARD_TITLE = "FamilyBoard"
-_DASHBOARD_ICON = "mdi:home-heart"
-
-
-async def _async_seed_dashboard(hass: HomeAssistant) -> None:
-    """Seed a storage-mode Lovelace dashboard for FamilyBoard, once.
-
-    Creates a sidebar entry that renders via the ``custom:familyboard``
-    strategy. The user can edit the dashboard freely afterwards; we only
-    create it if no dashboard with our ``url_path`` exists yet.
-    """
-    try:
-        from homeassistant.components import frontend
-        from homeassistant.components.lovelace import dashboard as lovelace_dashboard
-        from homeassistant.components.lovelace.const import LOVELACE_DATA
-    except ImportError:
-        _LOGGER.debug("Lovelace not available; skipping dashboard seed")
-        return
-
-    lovelace_data = hass.data.get(LOVELACE_DATA)
-    if lovelace_data is None:
-        _LOGGER.debug("Lovelace data not initialised; skipping dashboard seed")
-        return
-
-    # If we already registered (this run or a previous one), nothing to do.
-    if _DASHBOARD_URL_PATH in lovelace_data.dashboards:
-        return
-
-    collection = lovelace_dashboard.DashboardsCollection(hass)
-    try:
-        await collection.async_load()
-    except HomeAssistantError as err:
-        _LOGGER.warning("Could not load Lovelace dashboards collection: %s", err)
-        return
-
-    already_persisted = any(
-        item.get("url_path") == _DASHBOARD_URL_PATH for item in collection.async_items()
-    )
-
-    if not already_persisted:
-        try:
-            await collection.async_create_item(
-                {
-                    "allow_single_word": True,
-                    "icon": _DASHBOARD_ICON,
-                    "title": _DASHBOARD_TITLE,
-                    "url_path": _DASHBOARD_URL_PATH,
-                    "show_in_sidebar": True,
-                    "require_admin": False,
-                    "mode": "storage",
-                }
-            )
-        except (HomeAssistantError, vol.Invalid) as err:
-            _LOGGER.warning("Could not create FamilyBoard dashboard: %s", err)
-            return
-
-    # Wire up the in-memory LovelaceStorage + sidebar panel ourselves, since
-    # the lovelace component's collection listener only runs for changes made
-    # to its own collection instance during initial setup.
-    item = next(
-        (
-            i
-            for i in collection.async_items()
-            if i.get("url_path") == _DASHBOARD_URL_PATH
-        ),
-        None,
-    )
-    if item is None:
-        return
-
-    storage = lovelace_dashboard.LovelaceStorage(hass, item)
-    lovelace_data.dashboards[_DASHBOARD_URL_PATH] = storage
-
-    # Seed the dashboard config with our strategy on first creation only.
-    if not already_persisted:
-        try:
-            await storage.async_save(
-                {"strategy": {"type": "custom:familyboard"}, "title": _DASHBOARD_TITLE}
-            )
-        except HomeAssistantError as err:
-            _LOGGER.warning("Could not save FamilyBoard dashboard config: %s", err)
-
-    try:
-        frontend.async_register_built_in_panel(
-            hass,
-            "lovelace",
-            sidebar_title=_DASHBOARD_TITLE,
-            sidebar_icon=_DASHBOARD_ICON,
-            frontend_url_path=_DASHBOARD_URL_PATH,
-            require_admin=False,
-            config={"mode": "storage"},
-            update=True,
-        )
-        _LOGGER.info("Registered FamilyBoard dashboard at /%s", _DASHBOARD_URL_PATH)
-    except ValueError as err:
-        _LOGGER.debug("FamilyBoard dashboard panel already present: %s", err)
-
-
 async def _async_check_lovelace_dependencies(hass: HomeAssistant) -> None:
     """Warn if required HACS frontend deps (mushroom, card-mod) are missing."""
-    required = {
-        "mushroom": "Mushroom Cards",
-        "card-mod": "card-mod",
-        "bubble-card": "Bubble Card",
-    }
+    required = {"mushroom": "Mushroom Cards", "card-mod": "card-mod"}
     found: set[str] = set()
 
     lovelace_data = hass.data.get("lovelace")
@@ -688,15 +591,15 @@ class FamilyBoardCoordinator(DataUpdateCoordinator):
             return None
         view = view_state.state
         today = now.date()
-        if view == "Vandaag":
+        if view == "today":
             return (today.isoformat(), today.isoformat())
-        if view == "Morgen":
+        if view == "tomorrow":
             return (today.isoformat(), (today + timedelta(days=1)).isoformat())
-        if view == "Week":
+        if view == "week":
             return (today.isoformat(), (today + timedelta(days=7)).isoformat())
-        if view == "2 Weken":
+        if view == "two_weeks":
             return (today.isoformat(), (today + timedelta(days=14)).isoformat())
-        if view == "Maand":
+        if view == "month":
             return (today.isoformat(), (today + timedelta(days=30)).isoformat())
         return None
 
@@ -1013,6 +916,7 @@ class FamilyBoardCoordinator(DataUpdateCoordinator):
                 _LOGGER.exception("Reminder sync failed")
 
         result["meals"] = await self._fetch_meals(now)
+        result["recent_meals"] = await self._fetch_recent_meals(now)
 
         return result
 
@@ -1045,16 +949,48 @@ class FamilyBoardCoordinator(DataUpdateCoordinator):
             date = start[:10] if start else ""
             if not date:
                 continue
+            title = ev.get("summary", "")
             meals.append(
                 {
                     "date": date,
-                    "title": ev.get("summary", ""),
+                    "title": title,
                     "start": start,
                     "end": end,
                     "description": ev.get("description", ""),
                     "uid": ev.get("uid", ""),
                     "all_day": "T" not in start,
+                    "status": "skipped" if is_meal_placeholder(title) else "planned",
                 }
             )
         meals.sort(key=lambda m: m["start"])
         return meals
+
+    async def _fetch_recent_meals(self, now: _dt) -> list[dict]:
+        """Fetch and score recently-used meal titles for the picker.
+
+        Window: ``MEAL_RECENT_WINDOW_DAYS`` back through today. Returns the
+        top results from :func:`score_recent_meals`.
+        """
+        meal_entity = self.conf.get("meal_calendar")
+        if not meal_entity:
+            return []
+
+        today = now.date()
+        window_start = _dt.combine(
+            today - timedelta(days=MEAL_RECENT_WINDOW_DAYS),
+            time.min,
+            tzinfo=now.tzinfo,
+        )
+        window_end = _dt.combine(today, time.max, tzinfo=now.tzinfo)
+        events = await self._fetch_events(
+            meal_entity, window_start.isoformat(), window_end.isoformat()
+        )
+
+        normalised: list[dict] = []
+        for ev in events:
+            start = ev.get("start") or ""
+            date = start[:10]
+            if not date:
+                continue
+            normalised.append({"title": ev.get("summary", ""), "date": date})
+        return score_recent_meals(normalised, today)

--- a/custom_components/familyboard/binary_sensor.py
+++ b/custom_components/familyboard/binary_sensor.py
@@ -47,6 +47,7 @@ class FamilyBoardMealsUnplannedBinarySensor(CoordinatorEntity, BinarySensorEntit
         """Store the coordinator reference."""
         super().__init__(coordinator)
         self._attr_unique_id = "familyboard_meals_unplanned"
+        self._attr_suggested_object_id = "familyboard_meals_unplanned"
         self._attr_icon = "mdi:silverware-variant"
         self._attr_device_info = get_device_info()
 

--- a/custom_components/familyboard/binary_sensor.py
+++ b/custom_components/familyboard/binary_sensor.py
@@ -1,0 +1,86 @@
+"""Binary sensors for FamilyBoard.
+
+- `binary_sensor.familyboard_meals_unplanned` — on when one or more of
+  the upcoming ``MEAL_LOOKAHEAD_DAYS`` has no meal event at all.
+  Placeholder events (`MEAL_EMPTY_TITLES`, e.g. "geen") count as
+  planned, so deliberately-skipped days do not trigger the alert.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN, MEAL_LOOKAHEAD_DAYS, get_device_info
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up FamilyBoard binary sensor entities from a config entry."""
+    coordinator = hass.data[DOMAIN]["coordinator"]
+    async_add_entities([FamilyBoardMealsUnplannedBinarySensor(coordinator)], True)
+
+
+class FamilyBoardMealsUnplannedBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Binary sensor that flags upcoming days with no meal planned."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "meals_unplanned"
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+
+    def __init__(self, coordinator: DataUpdateCoordinator) -> None:
+        """Store the coordinator reference."""
+        super().__init__(coordinator)
+        self._attr_unique_id = "familyboard_meals_unplanned"
+        self._attr_icon = "mdi:silverware-variant"
+        self._attr_device_info = get_device_info()
+
+    def _meals_by_date(self) -> dict[str, list[dict]]:
+        """Group upcoming meals by ISO date."""
+        out: dict[str, list[dict]] = {}
+        if not self.coordinator.data:
+            return out
+        for meal in self.coordinator.data.get("meals", []):
+            out.setdefault(meal["date"], []).append(meal)
+        return out
+
+    def _unplanned_dates(self) -> list[str]:
+        """Return ISO dates in the lookahead window with no meal at all."""
+        meals_by_date = self._meals_by_date()
+        today = dt_util.now().date()
+        dates: list[str] = []
+        for offset in range(MEAL_LOOKAHEAD_DAYS):
+            iso = (today + timedelta(days=offset)).isoformat()
+            if not meals_by_date.get(iso):
+                dates.append(iso)
+        return dates
+
+    @property
+    def is_on(self) -> bool:
+        """Return True when any upcoming day lacks a meal entry."""
+        return bool(self._unplanned_dates())
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Expose the unplanned dates for automations and cards."""
+        dates = self._unplanned_dates()
+        return {
+            "unplanned_dates": dates,
+            "count": len(dates),
+            "next_unplanned": dates[0] if dates else None,
+        }

--- a/custom_components/familyboard/config_flow.py
+++ b/custom_components/familyboard/config_flow.py
@@ -103,14 +103,14 @@ class FamilyBoardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_import(self, import_data: dict[str, Any]) -> FlowResult:
         """Import options from YAML.
 
-        ``import_data`` is the validated ``familyboard:`` block.
+        ``import_data`` is the validated ``familyboard:`` block. Existing
+        UI-only options (e.g. ``meal_calendar`` set via the General step)
+        are preserved when YAML does not explicitly set them.
         """
         await self.async_set_unique_id(DOMAIN)
-        # If an entry already exists, refresh its options from YAML.
         for entry in self._async_current_entries():
-            self.hass.config_entries.async_update_entry(
-                entry, options=_normalize_options(import_data)
-            )
+            merged = _normalize_options(import_data, existing=dict(entry.options))
+            self.hass.config_entries.async_update_entry(entry, options=merged)
             return self.async_abort(reason="single_instance_allowed")
         return self.async_create_entry(
             title=DEVICE_NAME,
@@ -127,8 +127,15 @@ class FamilyBoardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return FamilyBoardOptionsFlow()
 
 
-def _normalize_options(raw: dict[str, Any]) -> dict[str, Any]:
-    """Coerce a (possibly-partial) YAML/options dict into the options shape."""
+def _normalize_options(
+    raw: dict[str, Any], existing: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Coerce a (possibly-partial) YAML/options dict into the options shape.
+
+    When ``existing`` is provided, UI-only keys absent from ``raw`` are
+    carried over so a YAML re-import does not wipe values configured
+    through the options flow (e.g. ``meal_calendar``).
+    """
     base = default_options()
     base.update(
         {
@@ -138,6 +145,11 @@ def _normalize_options(raw: dict[str, Any]) -> dict[str, Any]:
             "shared_chores": list(raw.get("shared_chores") or []),
         }
     )
+    meal = raw.get("meal_calendar")
+    if not meal and existing:
+        meal = existing.get("meal_calendar")
+    if meal:
+        base["meal_calendar"] = meal
     return base
 
 

--- a/custom_components/familyboard/config_flow.py
+++ b/custom_components/familyboard/config_flow.py
@@ -194,8 +194,38 @@ class FamilyBoardOptionsFlow(config_entries.OptionsFlow):
                 "trash",
                 "shared_calendars",
                 "shared_chores",
+                "general",
                 "save",
             ],
+        )
+
+    async def async_step_general(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Edit miscellaneous integration-wide settings (e.g. meal calendar).
+
+        Persists immediately on submit so the user does not need to also
+        click "Save and exit" — matching the behaviour of the per-entity
+        edit steps.
+        """
+        if user_input is not None:
+            meal = (user_input.get("meal_calendar") or "").strip()
+            if meal:
+                self._options["meal_calendar"] = meal
+            else:
+                self._options.pop("meal_calendar", None)
+            return self.async_create_entry(title="", data=self._options)
+
+        return self.async_show_form(
+            step_id="general",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        "meal_calendar",
+                        default=self._options.get("meal_calendar", ""),
+                    ): _entity("calendar"),
+                }
+            ),
         )
 
     async def async_step_save(

--- a/custom_components/familyboard/const.py
+++ b/custom_components/familyboard/const.py
@@ -39,6 +39,11 @@ EVENT_END_ENTITY = "datetime.familyboard_event_end"
 DAY_START_ENTITY = "datetime.familyboard_day_start"
 DAY_END_ENTITY = "datetime.familyboard_day_end"
 
+# Event countdown (FR-12) — user-editable label + target date,
+# rendered by the `familyboard-countdown-card` Lovelace card.
+COUNTDOWN_LABEL_ENTITY = "text.familyboard_countdown_label"
+COUNTDOWN_DATE_ENTITY = "datetime.familyboard_countdown_date"
+
 # Snooze / reminder engine
 STORAGE_KEY = "familyboard_reminders"
 STORAGE_VERSION = 1

--- a/custom_components/familyboard/const.py
+++ b/custom_components/familyboard/const.py
@@ -56,3 +56,9 @@ SNOOZE_MAX_MIN = 240
 VIEW_OPTIONS = ["Vandaag", "Morgen", "Week", "2 Weken", "Maand"]
 LAYOUT_OPTIONS = ["Lijst", "Agenda"]
 ALLES = "Alles"
+
+# Meal planning (Phase 1: calendar-backed display)
+MEALS_ENTITY = "sensor.familyboard_meals"
+MEAL_DEFAULT_HOUR = 18
+MEAL_LOOKAHEAD_DAYS = 7
+MEAL_PLACEHOLDER = "Nog niet gepland"

--- a/custom_components/familyboard/const.py
+++ b/custom_components/familyboard/const.py
@@ -52,13 +52,44 @@ SNOOZE_STEP_MIN = 15
 SNOOZE_LARGE_STEP_MIN = 60
 SNOOZE_MAX_MIN = 240
 
-# View / filter options (Dutch values; full i18n is a follow-up phase)
-VIEW_OPTIONS = ["Vandaag", "Morgen", "Week", "2 Weken", "Maand"]
-LAYOUT_OPTIONS = ["Lijst", "Agenda"]
+# View / filter options. Stable, language-neutral keys; user-visible labels
+# come from translations (entity.select.<key>.state.<key>).
+VIEW_OPTIONS = ["today", "tomorrow", "week", "two_weeks", "month"]
+LAYOUT_OPTIONS = ["list", "agenda"]
 ALLES = "Alles"
+# Legacy Dutch state values from earlier releases — restored states are mapped
+# into the new keys to avoid breaking existing installs.
+LEGACY_VIEW_STATE_MAP: dict[str, str] = {
+    "Vandaag": "today",
+    "Morgen": "tomorrow",
+    "Week": "week",
+    "2 Weken": "two_weeks",
+    "Maand": "month",
+}
+LEGACY_LAYOUT_STATE_MAP: dict[str, str] = {
+    "Lijst": "list",
+    "Agenda": "agenda",
+}
 
 # Meal planning (Phase 1: calendar-backed display)
 MEALS_ENTITY = "sensor.familyboard_meals"
+MEALS_UNPLANNED_ENTITY = "binary_sensor.familyboard_meals_unplanned"
+RECENT_MEALS_ENTITY = "sensor.familyboard_recent_meals"
 MEAL_DEFAULT_HOUR = 18
 MEAL_LOOKAHEAD_DAYS = 7
 MEAL_PLACEHOLDER = "Nog niet gepland"
+# Titles that mean "deliberately no meal" — count as planned, render 🚫.
+MEAL_EMPTY_TITLES = frozenset({"", "-", "--", "?", "geen", "none", "n/a"})
+
+# Phase 2: recent meals memory + scoring
+MEAL_RECENT_WINDOW_DAYS = 90
+MEAL_PICKER_LIMIT = 12
+# Penalty anchors: days_since_last_use → penalty subtracted from use count.
+# Linear interpolation between anchors; 30+ days → 0.
+MEAL_PENALTY_ANCHORS: tuple[tuple[int, float], ...] = (
+    (0, 10.0),
+    (3, 6.0),
+    (7, 3.0),
+    (14, 1.0),
+    (30, 0.0),
+)

--- a/custom_components/familyboard/datetime.py
+++ b/custom_components/familyboard/datetime.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import contextlib
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
 
 from homeassistant.components.datetime import DateTimeEntity
@@ -26,6 +26,7 @@ async def async_setup_entry(
     """Set up FamilyBoard datetime entities from a config entry."""
     now = dt_util.now().replace(minute=0, second=0, microsecond=0)
     end = now.replace(hour=now.hour + 1) if now.hour < 23 else now
+    countdown_default = (now + timedelta(days=7)).replace(hour=0)
 
     entities = [
         FamilyBoardDateTime(
@@ -52,6 +53,12 @@ async def async_setup_entry(
             icon="mdi:calendar-end",
             initial=end,
         ),
+        FamilyBoardDateTime(
+            unique_id="familyboard_countdown_date",
+            translation_key="countdown_date",
+            icon="mdi:calendar-end",
+            initial=countdown_default,
+        ),
     ]
     async_add_entities(entities, True)
     fb = hass.data.setdefault(DOMAIN, {})
@@ -60,6 +67,7 @@ async def async_setup_entry(
         "event_end": entities[1],
         "day_start": entities[2],
         "day_end": entities[3],
+        "countdown_date": entities[4],
     }
 
 
@@ -74,6 +82,7 @@ class FamilyBoardDateTime(DateTimeEntity, RestoreEntity):
     ) -> None:
         """Initialize the datetime entity with metadata and initial value."""
         self._attr_unique_id = unique_id
+        self._attr_suggested_object_id = unique_id
         self._attr_translation_key = translation_key
         self._attr_icon = icon
         self._attr_native_value = initial

--- a/custom_components/familyboard/frontend/familyboard-calendar-card.js
+++ b/custom_components/familyboard/frontend/familyboard-calendar-card.js
@@ -112,6 +112,7 @@ class FamilyBoardCalendarCard extends HTMLElement {
       show_now_indicator: config.show_now_indicator !== false,
       show_navigation: config.show_navigation !== false,
       weather_entity: config.weather_entity || null,
+      weather_show_low: config.weather_show_low === true,
       locale: config.locale || "nl",
     };
     if (this._config.end_hour <= this._config.start_hour) {
@@ -386,6 +387,106 @@ class FamilyBoardCalendarCard extends HTMLElement {
     if (key === this._fetchKey) return;
     this._fetchKey = key;
     this._fetchEvents(ents, start, end);
+    this._maybeFetchWeather();
+  }
+
+  async _maybeFetchWeather() {
+    const ent = this._config.weather_entity;
+    if (!ent || !this._hass) return;
+    const now = Date.now();
+    if (
+      this._weather &&
+      this._weather.entityId === ent &&
+      now - this._weather.fetchedAt < 15 * 60 * 1000
+    ) {
+      return;
+    }
+    try {
+      const resp = await this._hass.callWS({
+        type: "call_service",
+        domain: "weather",
+        service: "get_forecasts",
+        service_data: { type: "daily" },
+        target: { entity_id: ent },
+        return_response: true,
+      });
+      const list = resp?.response?.[ent]?.forecast || [];
+      const byDate = {};
+      for (const f of list) {
+        const d = new Date(f.datetime);
+        const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+        byDate[key] = {
+          condition: f.condition,
+          temperature: f.temperature,
+          templow: f.templow,
+        };
+      }
+      this._weather = { entityId: ent, fetchedAt: now, byDate };
+      this._render();
+    } catch (e) {
+      console.warn("familyboard-calendar-card: weather fetch failed", e);
+    }
+  }
+
+  _weatherForDay(date) {
+    if (!this._weather) return null;
+    const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+    return this._weather.byDate[key] || null;
+  }
+
+  _weatherIcon(condition) {
+    const map = {
+      "clear-night": "mdi:weather-night",
+      cloudy: "mdi:weather-cloudy",
+      exceptional: "mdi:alert-circle-outline",
+      fog: "mdi:weather-fog",
+      hail: "mdi:weather-hail",
+      lightning: "mdi:weather-lightning",
+      "lightning-rainy": "mdi:weather-lightning-rainy",
+      partlycloudy: "mdi:weather-partly-cloudy",
+      pouring: "mdi:weather-pouring",
+      rainy: "mdi:weather-rainy",
+      snowy: "mdi:weather-snowy",
+      "snowy-rainy": "mdi:weather-snowy-rainy",
+      sunny: "mdi:weather-sunny",
+      windy: "mdi:weather-windy",
+      "windy-variant": "mdi:weather-windy-variant",
+    };
+    return map[condition] || "mdi:weather-cloudy";
+  }
+
+  _weatherColor(condition) {
+    const map = {
+      sunny: "#fbc02d",
+      "clear-night": "#90caf9",
+      partlycloudy: "#fdd835",
+      cloudy: "#b0bec5",
+      fog: "#cfd8dc",
+      hail: "#81d4fa",
+      lightning: "#ffb300",
+      "lightning-rainy": "#ffb300",
+      pouring: "#1976d2",
+      rainy: "#42a5f5",
+      snowy: "#e1f5fe",
+      "snowy-rainy": "#b3e5fc",
+      windy: "#90a4ae",
+      "windy-variant": "#90a4ae",
+      exceptional: "#ef5350",
+    };
+    return map[condition] || "currentColor";
+  }
+
+  _renderWeather(date) {
+    const f = this._weatherForDay(date);
+    if (!f) return "";
+    const icon = this._weatherIcon(f.condition);
+    const color = this._weatherColor(f.condition);
+    const high = f.temperature != null ? `${Math.round(f.temperature)}\u00b0` : "";
+    if (this._config.weather_show_low && f.templow != null) {
+      const low = `${Math.round(f.templow)}\u00b0`;
+      return `<div class="fb-day-wx"><ha-icon icon="${icon}" style="color:${color}"></ha-icon><span class="fb-wx-temps"><span class="fb-wx-lo">${low}</span> / <span class="fb-wx-hi">${high}</span></span></div>`;
+    }
+    return `<div class="fb-day-wx"><ha-icon icon="${icon}" style="color:${color}"></ha-icon><span class="fb-wx-hi">${high}</span></div>`;
   }
 
   async _fetchEvents(entities, start, end) {
@@ -647,7 +748,7 @@ class FamilyBoardCalendarCard extends HTMLElement {
         display: contents;
       }
       .fb-day-header {
-        padding: 6px 4px;
+        padding: 6px 8px;
         text-align: center;
         border-bottom: 1px solid var(--fb-border);
         font-size: 0.85em;
@@ -658,6 +759,20 @@ class FamilyBoardCalendarCard extends HTMLElement {
       .fb-day-header.today { color: var(--primary-color); font-weight: 600; }
       .fb-day-header .fb-dow { font-size: 0.75em; opacity: 0.7; }
       .fb-day-header .fb-dnum { font-size: 1.1em; }
+      .fb-day-header .fb-day-date { line-height: 1.15; }
+      .fb-day-wx {
+        position: absolute;
+        right: 8px;
+        top: 50%;
+        transform: translateY(-50%);
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        font-size: 0.85em;
+        opacity: 0.95;
+      }
+      .fb-day-wx ha-icon { --mdc-icon-size: 20px; }
+      .fb-day-wx .fb-wx-lo { opacity: 0.65; }
 
       .fb-allday-row {
         display: contents;
@@ -747,6 +862,27 @@ class FamilyBoardCalendarCard extends HTMLElement {
         display: -webkit-box;
         -webkit-line-clamp: 2;
         -webkit-box-orient: vertical;
+      }
+      .fb-event.fb-compact {
+        padding: 2px 6px;
+        line-height: 1.1;
+        display: flex;
+        align-items: center;
+      }
+      .fb-event.fb-compact .fb-ev-line {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-size: 0.78em;
+        width: 100%;
+      }
+      .fb-event.fb-compact .fb-ev-time {
+        font-weight: 600;
+        margin-right: 4px;
+      }
+      .fb-event.fb-compact .fb-ev-title {
+        font-weight: 400;
+        display: inline;
       }
       .fb-event.fb-clipped-top::before,
       .fb-event.fb-clipped-bot::after {
@@ -893,9 +1029,13 @@ class FamilyBoardCalendarCard extends HTMLElement {
     for (let i = 0; i < numDays; i++) {
       const d = days[i];
       const isToday = this._isSameDay(d, today);
-      dayHeaders += `<div class="fb-day-header${isToday ? " today" : ""}">
-        <div class="fb-dow">${d.toLocaleDateString(cfg.locale, { weekday: "short" })}</div>
-        <div class="fb-dnum">${d.getDate()}</div>
+      const wx = this._renderWeather(d);
+      dayHeaders += `<div class="fb-day-header${isToday ? " today" : ""}${wx ? " has-wx" : ""}">
+        <div class="fb-day-date">
+          <div class="fb-dow">${d.toLocaleDateString(cfg.locale, { weekday: "short" })}</div>
+          <div class="fb-dnum">${d.getDate()}</div>
+        </div>
+        ${wx}
       </div>`;
       const adHtml = eventsByDay[i].allDay
         .map((ev, idx) => this._renderAllDayBlock(ev, idx))
@@ -946,9 +1086,8 @@ class FamilyBoardCalendarCard extends HTMLElement {
       // Smart-skip endHour label too if no event overlaps the previous hour
       if (h === endHour && occupiedHours && !occupiedHours.has(h - 1)) continue;
       const top = (h - startHour) * hourHeight;
-      let translate = "translateY(-50%)";
-      if (h === startHour) translate = "translateY(0)";
-      else if (h === endHour) translate = "translateY(-100%)";
+      let translate = "translateY(2px)";
+      if (h === endHour) translate = "translateY(-100%)";
       const label = h === 24 ? "24:00" : `${String(h).padStart(2, "0")}:00`;
       html += `<div class="fb-hour-label" style="position:absolute;top:${top}px;right:4px;transform:${translate};">${label}</div>`;
     }
@@ -1084,14 +1223,17 @@ class FamilyBoardCalendarCard extends HTMLElement {
     if (visibleEnd <= visibleStart) return ""; // entirely outside range
 
     const top = ((visibleStart - startHour * 60) / 60) * hourHeight;
-    const height = Math.max(((visibleEnd - visibleStart) / 60) * hourHeight, 14);
+    const durationMin = visibleEnd - visibleStart;
+    const height = Math.max((durationMin / 60) * hourHeight, 22);
     const widthPct = 100 / slot.cols;
     const leftPct = slot.col * widthPct;
 
     const clippedTop = startMin < startHour * 60;
     const clippedBot = endMin > endHour * 60;
     const reminderCls = ev.isReminder ? " fb-reminder" : "";
-    const cls = `fb-event${clippedTop ? " fb-clipped-top" : ""}${clippedBot ? " fb-clipped-bot" : ""}${reminderCls}`;
+    const compact = !ev.allDay && durationMin <= 30;
+    const compactCls = compact ? " fb-compact" : "";
+    const cls = `fb-event${clippedTop ? " fb-clipped-top" : ""}${clippedBot ? " fb-clipped-bot" : ""}${reminderCls}${compactCls}`;
 
     const bg = this._eventBackground(ev);
     const time = ev.allDay ? "" : `${this._formatTime(ev.startDate)}`;
@@ -1101,12 +1243,15 @@ class FamilyBoardCalendarCard extends HTMLElement {
       ? `data-todo="${this._escape(ev.todoEntity || "")}" data-uid="${this._escape(ev.uid || "")}"`
       : `data-sources="${encodeURIComponent(JSON.stringify(ev.sources))}"`;
 
+    const inner = compact
+      ? `<div class=\"fb-ev-line\"><span class=\"fb-ev-time\">${time}</span> <span class=\"fb-ev-title\">${title}</span></div>`
+      : `<div class=\"fb-ev-time\">${time}</div><div class=\"fb-ev-title\">${title}</div>`;
+
     return `
       <div class="${cls}"
            ${dataAttr}
            style="top:${top}px;height:${height}px;left:calc(${leftPct}% + 1px);width:calc(${widthPct}% - 4px);background:${bg};">
-        <div class="fb-ev-time">${time}</div>
-        <div class="fb-ev-title">${title}</div>
+        ${inner}
       </div>
     `;
   }
@@ -1188,6 +1333,7 @@ const CALENDAR_EDITOR_SCHEMA = [
   { name: "filter_entity", selector: { entity: { domain: "select" } } },
   { name: "view_entity", selector: { entity: { domain: "select" } } },
   { name: "weather_entity", selector: { entity: { domain: "weather" } } },
+  { name: "weather_show_low", selector: { boolean: {} } },
   { name: "reminders_entity", selector: { entity: {} } },
   { name: "config_entity", selector: { entity: { domain: "sensor" } } },
   { name: "show_now_indicator", selector: { boolean: {} } },

--- a/custom_components/familyboard/frontend/familyboard-calendar-card.js
+++ b/custom_components/familyboard/frontend/familyboard-calendar-card.js
@@ -39,12 +39,13 @@
 
 const DEFAULT_COLORS = ["#4A90D9", "#27AE60", "#F39C12", "#9B59B6", "#E74C3C", "#1ABC9C"];
 const VIEW_NL = { day: "Vandaag", week: "Week", "2weeks": "2 Weken", month: "Maand" };
+// Map stable select-state keys to internal view modes.
 const VIEW_FROM_SELECT = {
-  Vandaag: "day",
-  Morgen: "day",
-  Week: "week",
-  "2 Weken": "2weeks",
-  Maand: "month",
+  today: "day",
+  tomorrow: "day",
+  week: "week",
+  two_weeks: "2weeks",
+  month: "month",
 };
 
 class FamilyBoardCalendarCard extends HTMLElement {
@@ -145,15 +146,15 @@ class FamilyBoardCalendarCard extends HTMLElement {
 
   _anchorCurrentStartFor(viewSelectState) {
     const today = this._startOfDay(new Date());
-    if (viewSelectState === "Vandaag") {
+    if (viewSelectState === "today") {
       this._currentStart = today;
-    } else if (viewSelectState === "Morgen") {
+    } else if (viewSelectState === "tomorrow") {
       this._currentStart = this._addDays(today, 1);
-    } else if (viewSelectState === "Week" || viewSelectState === "2 Weken") {
+    } else if (viewSelectState === "week" || viewSelectState === "two_weeks") {
       // snap to monday of current week
       const dow = (today.getDay() + 6) % 7; // Mon=0
       this._currentStart = this._addDays(today, -dow);
-    } else if (viewSelectState === "Maand") {
+    } else if (viewSelectState === "month") {
       this._currentStart = new Date(today.getFullYear(), today.getMonth(), 1);
     }
     this._fetchKey = null;
@@ -1150,8 +1151,108 @@ class FamilyBoardCalendarCard extends HTMLElement {
       "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
     }[c]));
   }
+
+  static getStubConfig() {
+    return {
+      entities: [],
+      view: "day",
+      filter_entity: "select.familyboard_calendar",
+      view_entity: "select.familyboard_view",
+    };
+  }
+
+  static async getConfigElement() {
+    await customElements.whenDefined("ha-form");
+    return document.createElement("familyboard-calendar-card-editor");
+  }
 }
 
+const CALENDAR_EDITOR_SCHEMA = [
+  {
+    name: "entities",
+    selector: { entity: { domain: "calendar", multiple: true } },
+  },
+  {
+    name: "view",
+    selector: {
+      select: {
+        options: [
+          { value: "day", label: "Day" },
+          { value: "week", label: "Week" },
+          { value: "2weeks", label: "2 Weeks" },
+          { value: "month", label: "Month" },
+        ],
+      },
+    },
+  },
+  { name: "filter_entity", selector: { entity: { domain: "select" } } },
+  { name: "view_entity", selector: { entity: { domain: "select" } } },
+  { name: "weather_entity", selector: { entity: { domain: "weather" } } },
+  { name: "reminders_entity", selector: { entity: {} } },
+  { name: "config_entity", selector: { entity: { domain: "sensor" } } },
+  { name: "show_now_indicator", selector: { boolean: {} } },
+  { name: "show_navigation", selector: { boolean: {} } },
+  { name: "start_hour", selector: { number: { min: 0, max: 23, mode: "box" } } },
+  { name: "end_hour", selector: { number: { min: 1, max: 24, mode: "box" } } },
+  {
+    name: "slot_minutes",
+    selector: {
+      select: {
+        options: [
+          { value: 15, label: "15" },
+          { value: 20, label: "20" },
+          { value: 30, label: "30" },
+          { value: 60, label: "60" },
+        ],
+      },
+    },
+  },
+  { name: "row_height", selector: { number: { min: 12, max: 80, mode: "box" } } },
+  { name: "locale", selector: { text: {} } },
+];
+
+class FamilyBoardCalendarCardEditor extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._form = null;
+    this._config = {};
+    this._hass = null;
+  }
+
+  setConfig(config) {
+    this._config = config || {};
+    this._update();
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    this._update();
+  }
+
+  _update() {
+    if (!this._form) {
+      this._form = document.createElement("ha-form");
+      this._form.computeLabel = (s) => s.label || s.name;
+      this._form.schema = CALENDAR_EDITOR_SCHEMA;
+      this._form.addEventListener("value-changed", (ev) => {
+        ev.stopPropagation();
+        this.dispatchEvent(
+          new CustomEvent("config-changed", {
+            detail: { config: ev.detail.value },
+            bubbles: true,
+            composed: true,
+          }),
+        );
+      });
+      this.shadowRoot.appendChild(this._form);
+    }
+    if (this._hass) this._form.hass = this._hass;
+    this._form.data = this._config;
+  }
+}
+
+customElements.define("familyboard-calendar-card-editor", FamilyBoardCalendarCardEditor);
 customElements.define("familyboard-calendar-card", FamilyBoardCalendarCard);
 
 window.customCards = window.customCards || [];
@@ -1165,8 +1266,16 @@ if (!window.customCards.find((c) => c.type === "familyboard-calendar-card")) {
   });
 }
 
+const FB_VERSION = (() => {
+  try {
+    return new URL(import.meta.url).searchParams.get("v") || "dev";
+  } catch (_e) {
+    return "dev";
+  }
+})();
+
 console.info(
-  "%c FAMILYBOARD-CALENDAR-CARD %c v0.1.0-phase1 ",
+  `%c FAMILYBOARD-CALENDAR-CARD %c v${FB_VERSION} `,
   "color:white;background:#4A90D9;font-weight:bold;",
   "color:#4A90D9;background:transparent;"
 );

--- a/custom_components/familyboard/frontend/familyboard-chores-card.js
+++ b/custom_components/familyboard/frontend/familyboard-chores-card.js
@@ -126,18 +126,18 @@ class FamilyBoardChoresCard extends HTMLElement {
     const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
     let endDate = null;
 
-    if (view === "Vandaag") {
+    if (view === "today") {
       endDate = new Date(today);
-    } else if (view === "Morgen") {
+    } else if (view === "tomorrow") {
       endDate = new Date(today);
       endDate.setDate(endDate.getDate() + 1);
-    } else if (view === "Week") {
+    } else if (view === "week") {
       endDate = new Date(today);
       endDate.setDate(endDate.getDate() + 7);
-    } else if (view === "2 Weken") {
+    } else if (view === "two_weeks") {
       endDate = new Date(today);
       endDate.setDate(endDate.getDate() + 14);
-    } else if (view === "Maand") {
+    } else if (view === "month") {
       endDate = new Date(today);
       endDate.setDate(endDate.getDate() + 30);
     }
@@ -598,8 +598,64 @@ class FamilyBoardChoresCard extends HTMLElement {
       members_entity: "sensor.familyboard_members",
     };
   }
+
+  static async getConfigElement() {
+    await customElements.whenDefined("ha-form");
+    return document.createElement("familyboard-chores-card-editor");
+  }
 }
 
+const CHORES_EDITOR_SCHEMA = [
+  { name: "entity", required: true, selector: { entity: { domain: "sensor" } } },
+  { name: "filter_entity", selector: { entity: { domain: "select" } } },
+  { name: "view_entity", selector: { entity: { domain: "select" } } },
+  { name: "members_entity", selector: { entity: { domain: "sensor" } } },
+  { name: "member", selector: { text: {} } },
+  { name: "show_header", selector: { boolean: {} } },
+];
+
+class FamilyBoardChoresCardEditor extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._form = null;
+    this._config = {};
+    this._hass = null;
+  }
+
+  setConfig(config) {
+    this._config = config || {};
+    this._update();
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    this._update();
+  }
+
+  _update() {
+    if (!this._form) {
+      this._form = document.createElement("ha-form");
+      this._form.computeLabel = (s) => s.label || s.name;
+      this._form.schema = CHORES_EDITOR_SCHEMA;
+      this._form.addEventListener("value-changed", (ev) => {
+        ev.stopPropagation();
+        this.dispatchEvent(
+          new CustomEvent("config-changed", {
+            detail: { config: ev.detail.value },
+            bubbles: true,
+            composed: true,
+          }),
+        );
+      });
+      this.shadowRoot.appendChild(this._form);
+    }
+    if (this._hass) this._form.hass = this._hass;
+    this._form.data = this._config;
+  }
+}
+
+customElements.define("familyboard-chores-card-editor", FamilyBoardChoresCardEditor);
 customElements.define("familyboard-chores-card", FamilyBoardChoresCard);
 
 window.customCards = window.customCards || [];

--- a/custom_components/familyboard/frontend/familyboard-countdown-card.js
+++ b/custom_components/familyboard/frontend/familyboard-countdown-card.js
@@ -1,0 +1,384 @@
+/**
+ * FamilyBoard Countdown Card
+ *
+ * Renders a single editable countdown to a target date, e.g.
+ * "⏳ Nog 12 dagen tot Zomervakantie!". Reads two FamilyBoard entities
+ * (`text.familyboard_countdown_label` + `datetime.familyboard_countdown_date`)
+ * and edits them in place via `text.set_value` / `datetime.set_value`, so
+ * the kiosk user can update the countdown without admin login.
+ *
+ * Config:
+ *   type: custom:familyboard-countdown-card
+ *   label_entity: text.familyboard_countdown_label    # optional
+ *   date_entity:  datetime.familyboard_countdown_date # optional
+ *   editable: true                                    # optional, default true
+ *
+ * Behaviour:
+ * - Hidden when label is empty.
+ * - `> 1` → "⏳ Nog N dagen tot LABEL!"
+ * - `1`   → "⏳ Morgen is het LABEL!"
+ * - `0`   → "🎉 Vandaag is het LABEL!"
+ * - `< 0` → card auto-clears the label once (idempotent), then hides.
+ * - Re-renders on entity state change AND every 60s for the day rollover.
+ */
+
+const DEFAULT_LABEL_ENTITY = "text.familyboard_countdown_label";
+const DEFAULT_DATE_ENTITY = "datetime.familyboard_countdown_date";
+
+/**
+ * Format the visible countdown line. Pure function, exported for tests.
+ * Returns "" when there's nothing to render (no label or expired).
+ */
+export function formatCountdown(label, daysRemaining) {
+  const trimmed = (label || "").trim();
+  if (!trimmed) return "";
+  if (daysRemaining > 1) return `⏳ Nog ${daysRemaining} dagen tot ${trimmed}!`;
+  if (daysRemaining === 1) return `⏳ Morgen is het ${trimmed}!`;
+  if (daysRemaining === 0) return `🎉 Vandaag is het ${trimmed}!`;
+  return "";
+}
+
+/**
+ * Compute days between today (local) and an ISO datetime string. Returns
+ * null when the date can't be parsed.
+ */
+export function daysUntil(targetIso, now = new Date()) {
+  if (!targetIso) return null;
+  const target = new Date(targetIso);
+  if (Number.isNaN(target.getTime())) return null;
+  const a = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const b = new Date(target.getFullYear(), target.getMonth(), target.getDate());
+  return Math.round((b - a) / 86400000);
+}
+
+class FamilyBoardCountdownCard extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._hass = null;
+    this._config = {};
+    this._editing = false;
+    this._cleared = null; // entity_id+date_iso we last auto-cleared for
+    this._tick = null;
+  }
+
+  setConfig(config) {
+    this._config = {
+      label_entity: (config && config.label_entity) || DEFAULT_LABEL_ENTITY,
+      date_entity: (config && config.date_entity) || DEFAULT_DATE_ENTITY,
+      editable: config && config.editable === false ? false : true,
+      ...config,
+    };
+    this._render();
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    this._maybeAutoClear();
+    this._render();
+  }
+
+  connectedCallback() {
+    if (this._tick) return;
+    this._tick = setInterval(() => this._render(), 60_000);
+  }
+
+  disconnectedCallback() {
+    if (this._tick) {
+      clearInterval(this._tick);
+      this._tick = null;
+    }
+  }
+
+  getCardSize() {
+    return 1;
+  }
+
+  static getStubConfig() {
+    return {
+      label_entity: DEFAULT_LABEL_ENTITY,
+      date_entity: DEFAULT_DATE_ENTITY,
+    };
+  }
+
+  _readState() {
+    if (!this._hass) return { label: "", dateIso: null };
+    const ls = this._hass.states[this._config.label_entity];
+    const ds = this._hass.states[this._config.date_entity];
+    const label = ls && ls.state && !["unknown", "unavailable"].includes(ls.state) ? ls.state : "";
+    const dateIso = ds && ds.state && !["unknown", "unavailable"].includes(ds.state) ? ds.state : null;
+    return { label, dateIso };
+  }
+
+  _maybeAutoClear() {
+    if (!this._hass) return;
+    const { label, dateIso } = this._readState();
+    if (!label.trim() || !dateIso) return;
+    const days = daysUntil(dateIso);
+    if (days === null || days >= 0) return;
+    const sig = `${this._config.label_entity}|${dateIso}`;
+    if (this._cleared === sig) return;
+    this._cleared = sig;
+    this._hass.callService("text", "set_value", { value: "" }, { entity_id: this._config.label_entity });
+  }
+
+  _render() {
+    if (!this._hass) return;
+
+    const { label, dateIso } = this._readState();
+    const days = daysUntil(dateIso);
+    const text = formatCountdown(label, days ?? -1);
+
+    // Hidden when nothing to show AND not currently editing.
+    if (!text && !this._editing) {
+      this.shadowRoot.innerHTML = "";
+      return;
+    }
+
+    if (this._editing) {
+      this._renderEditor(label, dateIso);
+      return;
+    }
+
+    this._renderDisplay(text);
+  }
+
+  _renderDisplay(text) {
+    const editable = this._config.editable !== false;
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host { display: block; }
+        ha-card {
+          padding: 14px 16px;
+          display: flex;
+          align-items: center;
+          gap: 12px;
+        }
+        .text {
+          flex: 1;
+          font-size: 1.15em;
+          line-height: 1.3;
+        }
+        button.gear {
+          background: none;
+          border: none;
+          color: var(--secondary-text-color);
+          cursor: pointer;
+          padding: 4px;
+          font-size: 1.1em;
+        }
+        button.gear:hover { color: var(--primary-text-color); }
+      </style>
+      <ha-card>
+        <div class="text">${this._esc(text)}</div>
+        ${editable ? `<button class="gear" title="Aanpassen" aria-label="Aanpassen">⚙️</button>` : ""}
+      </ha-card>
+    `;
+    if (editable) {
+      const btn = this.shadowRoot.querySelector("button.gear");
+      if (btn) btn.addEventListener("click", () => this._enterEdit());
+    }
+  }
+
+  _renderEditor(label, dateIso) {
+    const dateOnly = dateIso ? dateIso.slice(0, 10) : "";
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host { display: block; }
+        ha-card { padding: 14px 16px; }
+        form { display: flex; flex-direction: column; gap: 10px; }
+        label { font-size: 0.9em; color: var(--secondary-text-color); }
+        input {
+          padding: 6px 8px;
+          font: inherit;
+          color: var(--primary-text-color);
+          background: var(--card-background-color);
+          border: 1px solid var(--divider-color);
+          border-radius: 4px;
+        }
+        .row { display: flex; gap: 8px; justify-content: flex-end; }
+        button {
+          padding: 6px 12px;
+          font: inherit;
+          cursor: pointer;
+          background: var(--primary-color);
+          color: var(--text-primary-color);
+          border: none;
+          border-radius: 4px;
+        }
+        button.secondary {
+          background: transparent;
+          color: var(--secondary-text-color);
+          border: 1px solid var(--divider-color);
+        }
+      </style>
+      <ha-card>
+        <form>
+          <label for="cd-label">Label</label>
+          <input id="cd-label" type="text" maxlength="80" value="${this._esc(label)}" placeholder="Bv. Zomervakantie" />
+          <label for="cd-date">Datum</label>
+          <input id="cd-date" type="date" value="${this._esc(dateOnly)}" />
+          <div class="row">
+            <button type="button" class="secondary" data-act="cancel">Annuleer</button>
+            <button type="button" data-act="save">Opslaan</button>
+          </div>
+        </form>
+      </ha-card>
+    `;
+    const labelEl = this.shadowRoot.getElementById("cd-label");
+    const dateEl = this.shadowRoot.getElementById("cd-date");
+    this.shadowRoot
+      .querySelector('button[data-act="cancel"]')
+      .addEventListener("click", () => this._exitEdit());
+    this.shadowRoot
+      .querySelector('button[data-act="save"]')
+      .addEventListener("click", () => this._save(labelEl.value, dateEl.value));
+    if (labelEl && labelEl.focus) {
+      // Focus the label input for fast kiosk entry.
+      setTimeout(() => labelEl.focus(), 0);
+    }
+  }
+
+  _enterEdit() {
+    this._editing = true;
+    this._render();
+  }
+
+  _exitEdit() {
+    this._editing = false;
+    this._render();
+  }
+
+  async _save(rawLabel, rawDate) {
+    if (!this._hass) return;
+    const label = (rawLabel || "").trim();
+    // Reset the cleared sentinel so the next render evaluates fresh.
+    this._cleared = null;
+    const calls = [
+      this._hass.callService(
+        "text",
+        "set_value",
+        { value: label },
+        { entity_id: this._config.label_entity },
+      ),
+    ];
+    if (rawDate) {
+      // datetime.set_value expects a full ISO timestamp; pin to local midnight.
+      const iso = `${rawDate}T00:00:00`;
+      calls.push(
+        this._hass.callService(
+          "datetime",
+          "set_value",
+          { datetime: iso },
+          { entity_id: this._config.date_entity },
+        ),
+      );
+    }
+    try {
+      await Promise.all(calls);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error("familyboard-countdown-card: save failed", e);
+    }
+    this._editing = false;
+    this._render();
+  }
+
+  _esc(s) {
+    return String(s ?? "").replace(/[&<>"']/g, (c) => ({
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;",
+      "'": "&#39;",
+    })[c]);
+  }
+
+  static async getConfigElement() {
+    await customElements.whenDefined("ha-form");
+    return document.createElement("familyboard-countdown-card-editor");
+  }
+}
+
+const COUNTDOWN_EDITOR_SCHEMA = [
+  {
+    name: "label_entity",
+    required: true,
+    selector: { entity: { domain: "text" } },
+  },
+  {
+    name: "date_entity",
+    required: true,
+    selector: { entity: { domain: "datetime" } },
+  },
+  { name: "editable", selector: { boolean: {} } },
+];
+
+class FamilyBoardCountdownCardEditor extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._form = null;
+    this._config = {};
+    this._hass = null;
+  }
+
+  setConfig(config) {
+    this._config = config || {};
+    this._update();
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    this._update();
+  }
+
+  _update() {
+    if (!this._form) {
+      this._form = document.createElement("ha-form");
+      this._form.computeLabel = (s) => s.label || s.name;
+      this._form.schema = COUNTDOWN_EDITOR_SCHEMA;
+      this._form.addEventListener("value-changed", (ev) => {
+        ev.stopPropagation();
+        this.dispatchEvent(
+          new CustomEvent("config-changed", {
+            detail: { config: ev.detail.value },
+            bubbles: true,
+            composed: true,
+          }),
+        );
+      });
+      this.shadowRoot.appendChild(this._form);
+    }
+    if (this._hass) this._form.hass = this._hass;
+    this._form.data = this._config;
+  }
+}
+
+customElements.define("familyboard-countdown-card-editor", FamilyBoardCountdownCardEditor);
+customElements.define("familyboard-countdown-card", FamilyBoardCountdownCard);
+
+window.customCards = window.customCards || [];
+if (!window.customCards.find((c) => c.type === "familyboard-countdown-card")) {
+  window.customCards.push({
+    type: "familyboard-countdown-card",
+    name: "FamilyBoard Countdown Card",
+    description: "Editable countdown to a configurable target date.",
+    documentationURL: "https://github.com/apiest/FamilyBoard#lovelace-cards",
+    preview: false,
+  });
+}
+
+const FB_VERSION = (() => {
+  try {
+    return new URL(import.meta.url).searchParams.get("v") || "dev";
+  } catch (_e) {
+    return "dev";
+  }
+})();
+
+console.info(
+  `%c FAMILYBOARD-COUNTDOWN-CARD %c v${FB_VERSION} `,
+  "color:white;background:#4A90D9;font-weight:bold;",
+  "color:#4A90D9;background:transparent;",
+);

--- a/custom_components/familyboard/frontend/familyboard-filter-card.js
+++ b/custom_components/familyboard/frontend/familyboard-filter-card.js
@@ -215,8 +215,61 @@ class FamilyBoardFilterCard extends HTMLElement {
     this.shadowRoot.innerHTML = "";
     this.shadowRoot.appendChild(el);
   }
+
+  static async getConfigElement() {
+    await customElements.whenDefined("ha-form");
+    return document.createElement("familyboard-filter-card-editor");
+  }
 }
 
+const FILTER_EDITOR_SCHEMA = [
+  { name: "filter_entity", selector: { entity: { domain: "select" } } },
+  { name: "members_entity", selector: { entity: { domain: "sensor" } } },
+  { name: "show_alles", selector: { boolean: {} } },
+];
+
+class FamilyBoardFilterCardEditor extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._form = null;
+    this._config = {};
+    this._hass = null;
+  }
+
+  setConfig(config) {
+    this._config = config || {};
+    this._update();
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    this._update();
+  }
+
+  _update() {
+    if (!this._form) {
+      this._form = document.createElement("ha-form");
+      this._form.computeLabel = (s) => s.label || s.name;
+      this._form.schema = FILTER_EDITOR_SCHEMA;
+      this._form.addEventListener("value-changed", (ev) => {
+        ev.stopPropagation();
+        this.dispatchEvent(
+          new CustomEvent("config-changed", {
+            detail: { config: ev.detail.value },
+            bubbles: true,
+            composed: true,
+          }),
+        );
+      });
+      this.shadowRoot.appendChild(this._form);
+    }
+    if (this._hass) this._form.hass = this._hass;
+    this._form.data = this._config;
+  }
+}
+
+customElements.define("familyboard-filter-card-editor", FamilyBoardFilterCardEditor);
 customElements.define("familyboard-filter-card", FamilyBoardFilterCard);
 
 window.customCards = window.customCards || [];

--- a/custom_components/familyboard/frontend/familyboard-progress-card.js
+++ b/custom_components/familyboard/frontend/familyboard-progress-card.js
@@ -235,8 +235,63 @@ class FamilyBoardProgressCard extends HTMLElement {
       entity: "sensor.familyboard_progress",
     };
   }
+
+  static async getConfigElement() {
+    await customElements.whenDefined("ha-form");
+    return document.createElement("familyboard-progress-card-editor");
+  }
 }
 
+const PROGRESS_EDITOR_SCHEMA = [
+  {
+    name: "entity",
+    required: true,
+    selector: { entity: { domain: "sensor" } },
+  },
+];
+
+class FamilyBoardProgressCardEditor extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._form = null;
+    this._config = {};
+    this._hass = null;
+  }
+
+  setConfig(config) {
+    this._config = config || {};
+    this._update();
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    this._update();
+  }
+
+  _update() {
+    if (!this._form) {
+      this._form = document.createElement("ha-form");
+      this._form.computeLabel = (s) => s.label || s.name;
+      this._form.schema = PROGRESS_EDITOR_SCHEMA;
+      this._form.addEventListener("value-changed", (ev) => {
+        ev.stopPropagation();
+        this.dispatchEvent(
+          new CustomEvent("config-changed", {
+            detail: { config: ev.detail.value },
+            bubbles: true,
+            composed: true,
+          }),
+        );
+      });
+      this.shadowRoot.appendChild(this._form);
+    }
+    if (this._hass) this._form.hass = this._hass;
+    this._form.data = this._config;
+  }
+}
+
+customElements.define("familyboard-progress-card-editor", FamilyBoardProgressCardEditor);
 customElements.define("familyboard-progress-card", FamilyBoardProgressCard);
 
 window.customCards = window.customCards || [];

--- a/custom_components/familyboard/frontend/familyboard-strategy.js
+++ b/custom_components/familyboard/frontend/familyboard-strategy.js
@@ -32,6 +32,9 @@ const DEFAULTS = {
   show_calendar: true,
   show_chores: true,
   show_progress: true,
+  show_countdown: true,
+  countdown_label_entity: "text.familyboard_countdown_label",
+  countdown_date_entity: "datetime.familyboard_countdown_date",
   title: "Family Board",
   path: "familyboard",
   icon: "mdi:calendar-multiple",
@@ -306,6 +309,13 @@ function _todayPerMemberSection(cfg, members) {
 
 function _sideStackSection(cfg) {
   const stack = [];
+  if (cfg.show_countdown !== false) {
+    stack.push({
+      type: "custom:familyboard-countdown-card",
+      label_entity: cfg.countdown_label_entity,
+      date_entity: cfg.countdown_date_entity,
+    });
+  }
   if (cfg.show_progress) {
     stack.push({
       type: "custom:familyboard-progress-card",

--- a/custom_components/familyboard/frontend/familyboard-strategy.js
+++ b/custom_components/familyboard/frontend/familyboard-strategy.js
@@ -56,28 +56,11 @@ function _filterCard(cfg) {
 }
 
 function _viewChips(cfg) {
-  const opts = [
-    ["Vandaag", "mdi:calendar-today"],
-    ["Morgen", "mdi:calendar-arrow-right"],
-    ["Week", "mdi:calendar-week"],
-    ["2 Weken", "mdi:calendar-range"],
-    ["Maand", "mdi:calendar-month"],
-  ];
+  // Delegates label rendering + i18n to the dedicated view card.
   return {
-    type: "custom:mushroom-chips-card",
+    type: "custom:familyboard-view-card",
+    entity: cfg.view_entity,
     grid_options: { columns: 12, rows: 1 },
-    chips: opts.map(([opt, icon]) => ({
-      type: "template",
-      icon,
-      content: opt,
-      icon_color: `{{ 'amber' if is_state('${cfg.view_entity}', '${opt}') else 'grey' }}`,
-      tap_action: {
-        action: "perform-action",
-        perform_action: "select.select_option",
-        target: { entity_id: cfg.view_entity },
-        data: { option: opt },
-      },
-    })),
   };
 }
 
@@ -203,7 +186,7 @@ function _lijstCard(cfg, members) {
   })()`;
   return {
     type: "conditional",
-    conditions: [{ entity: cfg.layout_entity, state: "Lijst" }],
+    conditions: [{ entity: cfg.layout_entity, state: "list" }],
     card: {
       type: "custom:config-template-card",
       entities: [cfg.filter_entity, cfg.view_entity],
@@ -213,23 +196,23 @@ function _lijstCard(cfg, members) {
         VIEW: `states['${cfg.view_entity}'].state`,
         DAYS: `(() => {
             const v = states['${cfg.view_entity}'].state;
-            if (v === 'Vandaag') return 1;
-            if (v === 'Morgen') return 2;
-            if (v === 'Week') return 7;
-            if (v === '2 Weken') return 14;
+            if (v === 'today') return 1;
+            if (v === 'tomorrow') return 2;
+            if (v === 'week') return 7;
+            if (v === 'two_weeks') return 14;
             return 'month';
           })()`,
         STARTDAY: `(() => {
             const v = states['${cfg.view_entity}'].state;
-            if (v === 'Vandaag') return 'today';
-            if (v === 'Morgen') return 'tomorrow';
-            if (v === 'Week') return 'monday';
-            if (v === 'Maand') return 'monday';
+            if (v === 'today') return 'today';
+            if (v === 'tomorrow') return 'tomorrow';
+            if (v === 'week') return 'monday';
+            if (v === 'month') return 'monday';
             return 'today';
           })()`,
         COMPACT: `(() => {
             const v = states['${cfg.view_entity}'].state;
-            return v === 'Maand';
+            return v === 'month';
           })()`,
       },
       card: {
@@ -485,8 +468,16 @@ customElements.define(
   FamilyBoardViewStrategy
 );
 
+const FB_VERSION = (() => {
+  try {
+    return new URL(import.meta.url).searchParams.get("v") || "dev";
+  } catch (_e) {
+    return "dev";
+  }
+})();
+
 console.info(
-  "%c FAMILYBOARD-STRATEGY %c v1.0 ",
+  `%c FAMILYBOARD-STRATEGY %c v${FB_VERSION} `,
   "color: white; background: #4A90D9; font-weight: 700;",
   "color: #4A90D9; background: white; font-weight: 700;"
 );

--- a/custom_components/familyboard/frontend/familyboard-view-card.js
+++ b/custom_components/familyboard/frontend/familyboard-view-card.js
@@ -15,9 +15,13 @@
  *     today: mdi:calendar-today
  *     ...
  *   color: amber                                 # optional, selected color
+ *   show_reminders: true                         # optional, append a Herinneringen toggle chip
+ *   reminders_switch: switch.familyboard_show_reminders  # optional, entity backing the chip
+ *   extra_chips: []                              # optional, raw mushroom-chip dicts appended
  */
 
 const DEFAULT_ENTITY = "select.familyboard_view";
+const DEFAULT_REMINDERS_SWITCH = "switch.familyboard_show_reminders";
 
 const DEFAULT_ICONS = {
   today: "mdi:calendar-today",
@@ -67,6 +71,10 @@ class FamilyBoardViewCard extends HTMLElement {
       entity: config.entity || DEFAULT_ENTITY,
       icons: { ...DEFAULT_ICONS, ...(config.icons || {}) },
       color: config.color || "amber",
+      show_reminders: config.show_reminders === true,
+      reminders_switch: config.reminders_switch || DEFAULT_REMINDERS_SWITCH,
+      reminders_label: config.reminders_label || "Herinneringen",
+      extra_chips: Array.isArray(config.extra_chips) ? config.extra_chips : [],
       ...config,
     };
   }
@@ -103,7 +111,7 @@ class FamilyBoardViewCard extends HTMLElement {
   _buildChips(stateObj) {
     const options = stateObj?.attributes?.options || [];
     const current = stateObj?.state;
-    return options.map((opt) => ({
+    const chips = options.map((opt) => ({
       type: "template",
       icon: this._config.icons[opt] || "mdi:circle-outline",
       content: this._label(stateObj, opt),
@@ -115,6 +123,26 @@ class FamilyBoardViewCard extends HTMLElement {
         data: { option: opt },
       },
     }));
+    if (this._config.show_reminders) {
+      const swEntity = this._config.reminders_switch;
+      const sw = this._hass.states[swEntity];
+      const on = sw && sw.state === "on";
+      chips.push({
+        type: "template",
+        icon: on ? "mdi:bell" : "mdi:bell-off",
+        icon_color: on ? this._config.color : "grey",
+        content: this._config.reminders_label,
+        tap_action: {
+          action: "perform-action",
+          perform_action: "switch.toggle",
+          target: { entity_id: swEntity },
+        },
+      });
+    }
+    for (const extra of this._config.extra_chips) {
+      chips.push(extra);
+    }
+    return chips;
   }
 
   async _render() {
@@ -146,6 +174,10 @@ class FamilyBoardViewCard extends HTMLElement {
       o: stateObj.attributes.options,
       s: stateObj.state,
       lang: this._hass?.locale?.language || "",
+      x: this._config.extra_chips.length,
+      r: this._config.show_reminders
+        ? this._hass.states[this._config.reminders_switch]?.state || ""
+        : "",
     });
     if (sig === this._lastSig && this._inner) {
       this._inner.hass = this._hass;
@@ -180,6 +212,8 @@ class FamilyBoardViewCard extends HTMLElement {
 const VIEW_EDITOR_SCHEMA = [
   { name: "entity", required: true, selector: { entity: { domain: "select" } } },
   { name: "color", selector: { text: {} } },
+  { name: "show_reminders", selector: { boolean: {} } },
+  { name: "reminders_switch", selector: { entity: { domain: "switch" } } },
 ];
 
 class FamilyBoardViewCardEditor extends HTMLElement {

--- a/custom_components/familyboard/frontend/familyboard-view-card.js
+++ b/custom_components/familyboard/frontend/familyboard-view-card.js
@@ -1,0 +1,252 @@
+/**
+ * FamilyBoard View Card
+ *
+ * Renders chips for `select.familyboard_view` (or any select entity), reading
+ * the option list from `stateObj.attributes.options` and the user-visible
+ * label via `hass.formatEntityState(stateObj, option)` so labels follow the
+ * Home Assistant locale (state translations live in `translations/<lang>.json`).
+ *
+ * Wraps `mushroom-chips-card` for visual consistency with `familyboard-filter-card`.
+ *
+ * Config:
+ *   type: custom:familyboard-view-card
+ *   entity: select.familyboard_view              # optional
+ *   icons:                                       # optional, per option key
+ *     today: mdi:calendar-today
+ *     ...
+ *   color: amber                                 # optional, selected color
+ */
+
+const DEFAULT_ENTITY = "select.familyboard_view";
+
+const DEFAULT_ICONS = {
+  today: "mdi:calendar-today",
+  tomorrow: "mdi:calendar-arrow-right",
+  week: "mdi:calendar-week",
+  two_weeks: "mdi:calendar-range",
+  month: "mdi:calendar-month",
+  list: "mdi:view-list",
+  agenda: "mdi:calendar-star",
+};
+
+class FamilyBoardViewCard extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._hass = null;
+    this._config = {};
+    this._inner = null;
+    this._lastSig = null;
+    this._mushroomReady = false;
+    this._mushroomMissing = false;
+    this._init();
+  }
+
+  async _init() {
+    if (customElements.get("mushroom-chips-card")) {
+      this._mushroomReady = true;
+      return;
+    }
+    try {
+      await Promise.race([
+        customElements.whenDefined("mushroom-chips-card"),
+        new Promise((_, rej) => setTimeout(() => rej(new Error("timeout")), 5000)),
+      ]);
+      this._mushroomReady = true;
+      this._lastSig = null;
+      this._render();
+    } catch (e) {
+      this._mushroomMissing = true;
+      this._lastSig = null;
+      this._render();
+    }
+  }
+
+  setConfig(config) {
+    this._config = {
+      entity: config.entity || DEFAULT_ENTITY,
+      icons: { ...DEFAULT_ICONS, ...(config.icons || {}) },
+      color: config.color || "amber",
+      ...config,
+    };
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    this._render();
+  }
+
+  getCardSize() {
+    return 1;
+  }
+
+  getGridOptions() {
+    return { rows: 1, columns: 12, max_rows: 1 };
+  }
+
+  static getStubConfig() {
+    return { entity: DEFAULT_ENTITY };
+  }
+
+  _label(stateObj, option) {
+    if (this._hass && typeof this._hass.formatEntityState === "function") {
+      try {
+        return this._hass.formatEntityState(stateObj, option);
+      } catch (_e) {
+        /* fall through */
+      }
+    }
+    // Fallback: title-case the key.
+    return option.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  }
+
+  _buildChips(stateObj) {
+    const options = stateObj?.attributes?.options || [];
+    const current = stateObj?.state;
+    return options.map((opt) => ({
+      type: "template",
+      icon: this._config.icons[opt] || "mdi:circle-outline",
+      content: this._label(stateObj, opt),
+      icon_color: opt === current ? this._config.color : "grey",
+      tap_action: {
+        action: "perform-action",
+        perform_action: "select.select_option",
+        target: { entity_id: this._config.entity },
+        data: { option: opt },
+      },
+    }));
+  }
+
+  async _render() {
+    if (!this._hass) return;
+
+    if (this._mushroomMissing) {
+      this.shadowRoot.innerHTML = `
+        <ha-card>
+          <div style="padding:16px;color:var(--error-color);">
+            FamilyBoard View Card vereist <b>Mushroom Cards</b>.
+            Installeer via HACS en herstart.
+          </div>
+        </ha-card>`;
+      return;
+    }
+    if (!this._mushroomReady) {
+      this.shadowRoot.innerHTML = `<ha-card><div style="padding:8px;">Loading…</div></ha-card>`;
+      return;
+    }
+
+    const stateObj = this._hass.states[this._config.entity];
+    if (!stateObj) {
+      this.shadowRoot.innerHTML = `<ha-card><div style="padding:8px;color:var(--error-color);">${this._config.entity} not found</div></ha-card>`;
+      return;
+    }
+
+    const sig = JSON.stringify({
+      e: this._config.entity,
+      o: stateObj.attributes.options,
+      s: stateObj.state,
+      lang: this._hass?.locale?.language || "",
+    });
+    if (sig === this._lastSig && this._inner) {
+      this._inner.hass = this._hass;
+      return;
+    }
+    this._lastSig = sig;
+
+    const chips = this._buildChips(stateObj);
+    const cardConfig = { type: "custom:mushroom-chips-card", chips };
+
+    let helpers;
+    try {
+      helpers = await window.loadCardHelpers();
+    } catch (e) {
+      this.shadowRoot.innerHTML = `<ha-card><div style="padding:16px;color:var(--error-color);">loadCardHelpers unavailable</div></ha-card>`;
+      return;
+    }
+    const el = helpers.createCardElement(cardConfig);
+    el.hass = this._hass;
+    this._inner = el;
+
+    this.shadowRoot.innerHTML = "";
+    this.shadowRoot.appendChild(el);
+  }
+
+  static async getConfigElement() {
+    await customElements.whenDefined("ha-form");
+    return document.createElement("familyboard-view-card-editor");
+  }
+}
+
+const VIEW_EDITOR_SCHEMA = [
+  { name: "entity", required: true, selector: { entity: { domain: "select" } } },
+  { name: "color", selector: { text: {} } },
+];
+
+class FamilyBoardViewCardEditor extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._form = null;
+    this._config = {};
+    this._hass = null;
+  }
+
+  setConfig(config) {
+    this._config = config || {};
+    this._update();
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    this._update();
+  }
+
+  _update() {
+    if (!this._form) {
+      this._form = document.createElement("ha-form");
+      this._form.computeLabel = (s) => s.label || s.name;
+      this._form.schema = VIEW_EDITOR_SCHEMA;
+      this._form.addEventListener("value-changed", (ev) => {
+        ev.stopPropagation();
+        this.dispatchEvent(
+          new CustomEvent("config-changed", {
+            detail: { config: ev.detail.value },
+            bubbles: true,
+            composed: true,
+          }),
+        );
+      });
+      this.shadowRoot.appendChild(this._form);
+    }
+    if (this._hass) this._form.hass = this._hass;
+    this._form.data = this._config;
+  }
+}
+
+customElements.define("familyboard-view-card-editor", FamilyBoardViewCardEditor);
+customElements.define("familyboard-view-card", FamilyBoardViewCard);
+
+window.customCards = window.customCards || [];
+if (!window.customCards.find((c) => c.type === "familyboard-view-card")) {
+  window.customCards.push({
+    type: "familyboard-view-card",
+    name: "FamilyBoard View Card",
+    description: "Localized chip selector for any FamilyBoard select entity.",
+    documentationURL: "https://github.com/apiest/FamilyBoard#lovelace-cards",
+    preview: false,
+  });
+}
+
+const FB_VERSION = (() => {
+  try {
+    return new URL(import.meta.url).searchParams.get("v") || "dev";
+  } catch (_e) {
+    return "dev";
+  }
+})();
+
+console.info(
+  `%c FAMILYBOARD-VIEW-CARD %c v${FB_VERSION} `,
+  "color:white;background:#4A90D9;font-weight:bold;",
+  "color:#4A90D9;background:transparent;",
+);

--- a/custom_components/familyboard/helpers.py
+++ b/custom_components/familyboard/helpers.py
@@ -2,7 +2,84 @@
 
 from __future__ import annotations
 
+from datetime import date as _date
+from itertools import pairwise
 from typing import Any
+
+from .const import MEAL_EMPTY_TITLES, MEAL_PENALTY_ANCHORS, MEAL_PICKER_LIMIT
+
+
+def is_meal_placeholder(title: str | None) -> bool:
+    """Return True when the meal title means 'deliberately no meal'."""
+    if title is None:
+        return True
+    return title.strip().lower() in MEAL_EMPTY_TITLES
+
+
+def meal_penalty(days_since: int) -> float:
+    """Linear-interpolated penalty by days since last use; 30+ → 0."""
+    anchors = MEAL_PENALTY_ANCHORS
+    if days_since <= anchors[0][0]:
+        return anchors[0][1]
+    if days_since >= anchors[-1][0]:
+        return anchors[-1][1]
+    for (d0, p0), (d1, p1) in pairwise(anchors):
+        if d0 <= days_since <= d1:
+            if d1 == d0:
+                return p0
+            ratio = (days_since - d0) / (d1 - d0)
+            return p0 + (p1 - p0) * ratio
+    return 0.0
+
+
+def score_recent_meals(
+    events: list[dict[str, Any]],
+    today: _date,
+) -> list[dict[str, Any]]:
+    """Return scored, deduped recent meal titles sorted by score desc.
+
+    ``events`` items must have ``title`` and ``date`` (ISO yyyy-mm-dd).
+    Placeholders are skipped. Result is capped at ``MEAL_PICKER_LIMIT``.
+    """
+    grouped: dict[str, dict[str, Any]] = {}
+    for ev in events:
+        title = (ev.get("title") or "").strip()
+        if is_meal_placeholder(title):
+            continue
+        key = title.lower()
+        try:
+            ev_date = _date.fromisoformat(ev["date"])
+        except (KeyError, ValueError):
+            continue
+        entry = grouped.get(key)
+        if entry is None:
+            grouped[key] = {
+                "title": title,
+                "uses": 1,
+                "last_used": ev_date,
+            }
+        else:
+            entry["uses"] += 1
+            if ev_date > entry["last_used"]:
+                entry["last_used"] = ev_date
+                entry["title"] = title  # keep most-recent capitalisation
+
+    items: list[dict[str, Any]] = []
+    for entry in grouped.values():
+        days_since = (today - entry["last_used"]).days
+        score = entry["uses"] - meal_penalty(days_since)
+        items.append(
+            {
+                "title": entry["title"],
+                "uses": entry["uses"],
+                "last_used": entry["last_used"].isoformat(),
+                "days_since": days_since,
+                "score": round(score, 2),
+            }
+        )
+
+    items.sort(key=lambda i: (i["score"], -i["days_since"]), reverse=True)
+    return items[:MEAL_PICKER_LIMIT]
 
 
 def primary_label(member: dict[str, Any]) -> str:

--- a/custom_components/familyboard/manifest.json
+++ b/custom_components/familyboard/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/apiest/FamilyBoard/issues",
   "requirements": [],
-  "version": "0.1.0"
+  "version": "0.2.0"
 }

--- a/custom_components/familyboard/schemas.py
+++ b/custom_components/familyboard/schemas.py
@@ -70,6 +70,7 @@ OPTIONS_SCHEMA = vol.Schema(
         vol.Optional("shared_chores", default=[]): vol.All(
             cv.ensure_list, [SHARED_CHORE_SCHEMA]
         ),
+        vol.Optional("meal_calendar"): cv.entity_id,
     }
 )
 

--- a/custom_components/familyboard/select.py
+++ b/custom_components/familyboard/select.py
@@ -20,7 +20,15 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import ALLES, DOMAIN, LAYOUT_OPTIONS, VIEW_OPTIONS, get_device_info
+from .const import (
+    ALLES,
+    DOMAIN,
+    LAYOUT_OPTIONS,
+    LEGACY_LAYOUT_STATE_MAP,
+    LEGACY_VIEW_STATE_MAP,
+    VIEW_OPTIONS,
+    get_device_info,
+)
 from .helpers import member_calendar_labels
 
 _LOGGER = logging.getLogger(__name__)
@@ -49,16 +57,18 @@ async def async_setup_entry(
         translation_key="view",
         icon="mdi:eye",
         options=VIEW_OPTIONS,
-        default="Week",
+        default="week",
         object_id="familyboard_view",
+        legacy_state_map=LEGACY_VIEW_STATE_MAP,
     )
     layout = FamilyBoardSelect(
         unique_id="familyboard_layout",
         translation_key="layout",
         icon="mdi:view-dashboard-variant",
         options=LAYOUT_OPTIONS,
-        default="Lijst",
+        default="list",
         object_id="familyboard_layout",
+        legacy_state_map=LEGACY_LAYOUT_STATE_MAP,
     )
     event_member = FamilyBoardSelect(
         unique_id="familyboard_event_member",
@@ -101,6 +111,7 @@ class FamilyBoardSelect(SelectEntity, RestoreEntity):
         options: list[str],
         default: str | None,
         object_id: str | None = None,
+        legacy_state_map: dict[str, str] | None = None,
     ) -> None:
         """Initialize the select with metadata, options and default value."""
         self._attr_unique_id = unique_id
@@ -110,6 +121,7 @@ class FamilyBoardSelect(SelectEntity, RestoreEntity):
         self._attr_current_option = (
             default if default in options else (options[0] if options else None)
         )
+        self._legacy_state_map = legacy_state_map or {}
         self._attr_device_info = get_device_info()
         # Pin the entity_id so it matches the constants the dashboard uses,
         # regardless of what the translation key would otherwise produce.
@@ -121,8 +133,21 @@ class FamilyBoardSelect(SelectEntity, RestoreEntity):
         """Restore the previously selected option on startup."""
         await super().async_added_to_hass()
         last = await self.async_get_last_state()
-        if last and last.state in (self._attr_options or []):
-            self._attr_current_option = last.state
+        if not last:
+            return
+        state = last.state
+        if state in (self._attr_options or []):
+            self._attr_current_option = state
+        elif state in self._legacy_state_map:
+            mapped = self._legacy_state_map[state]
+            if mapped in (self._attr_options or []):
+                _LOGGER.info(
+                    "Migrating legacy %s state %r -> %r",
+                    self.entity_id,
+                    state,
+                    mapped,
+                )
+                self._attr_current_option = mapped
 
     async def async_select_option(self, option: str) -> None:
         """Select a new option, ignoring values not in the option list."""

--- a/custom_components/familyboard/sensor.py
+++ b/custom_components/familyboard/sensor.py
@@ -3,6 +3,7 @@
 - `sensor.familyboard_chores`     — combined chore list with datetime + uid
 - `sensor.familyboard_compliment` — time-of-day greeting
 - `sensor.familyboard_meals`      — today's meal + upcoming week
+- `sensor.familyboard_recent_meals` — scored recent meal titles for the picker
 - `sensor.familyboard_members`    — member metadata for cards
 - `sensor.familyboard_progress`   — per-member chore progress
 """
@@ -46,6 +47,7 @@ async def async_setup_entry(
             FamilyBoardChoresSensor(coordinator, conf),
             FamilyBoardComplimentSensor(),
             FamilyBoardMealsSensor(coordinator, conf),
+            FamilyBoardRecentMealsSensor(coordinator, conf),
             FamilyBoardMembersSensor(coordinator),
             FamilyBoardProgressSensor(coordinator),
         ],
@@ -261,5 +263,45 @@ class FamilyBoardMealsSensor(CoordinatorEntity, SensorEntity):
         return {
             "tonight": self._tonight(),
             "week": week,
+            "meal_calendar_entity": self._conf.get("meal_calendar"),
+        }
+
+
+class FamilyBoardRecentMealsSensor(CoordinatorEntity, SensorEntity):
+    """Sensor exposing recently used meal titles for the quick picker.
+
+    State is the number of distinct titles. Attributes expose ``items``
+    (the scored, deduped list capped at ``MEAL_PICKER_LIMIT``) and
+    ``meal_calendar_entity`` so cards can call ``calendar.create_event``
+    against the right target.
+    """
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "recent_meals"
+
+    def __init__(self, coordinator: DataUpdateCoordinator, conf: dict) -> None:
+        """Store the coordinator and resolved config."""
+        super().__init__(coordinator)
+        self._conf = conf
+        self._attr_unique_id = "familyboard_recent_meals"
+        self._attr_icon = "mdi:history"
+        self._attr_device_info = get_device_info()
+
+    def _items(self) -> list[dict]:
+        """Return the scored recent meals list from the coordinator."""
+        if not self.coordinator.data:
+            return []
+        return self.coordinator.data.get("recent_meals", [])
+
+    @property
+    def native_value(self) -> int:
+        """Return the number of distinct recent meal titles."""
+        return len(self._items())
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Expose the scored items + the meal calendar entity."""
+        return {
+            "items": self._items(),
             "meal_calendar_entity": self._conf.get("meal_calendar"),
         }

--- a/custom_components/familyboard/sensor.py
+++ b/custom_components/familyboard/sensor.py
@@ -2,12 +2,14 @@
 
 - `sensor.familyboard_chores`     — combined chore list with datetime + uid
 - `sensor.familyboard_compliment` — time-of-day greeting
+- `sensor.familyboard_meals`      — today's meal + upcoming week
 - `sensor.familyboard_members`    — member metadata for cards
 - `sensor.familyboard_progress`   — per-member chore progress
 """
 
 from __future__ import annotations
 
+from datetime import timedelta
 import logging
 
 from homeassistant.components.sensor import SensorEntity
@@ -20,7 +22,12 @@ from homeassistant.helpers.update_coordinator import (
 )
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN, get_device_info
+from .const import (
+    DOMAIN,
+    MEAL_LOOKAHEAD_DAYS,
+    MEAL_PLACEHOLDER,
+    get_device_info,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,6 +45,7 @@ async def async_setup_entry(
         [
             FamilyBoardChoresSensor(coordinator, conf),
             FamilyBoardComplimentSensor(),
+            FamilyBoardMealsSensor(coordinator, conf),
             FamilyBoardMembersSensor(coordinator),
             FamilyBoardProgressSensor(coordinator),
         ],
@@ -185,3 +193,73 @@ class FamilyBoardProgressSensor(CoordinatorEntity, SensorEntity):
                 }
             )
         return {"members": members}
+
+
+class FamilyBoardMealsSensor(CoordinatorEntity, SensorEntity):
+    """Sensor exposing tonight's meal + the upcoming week of meals.
+
+    State is the title of today's meal (or ``MEAL_PLACEHOLDER`` when
+    nothing is planned). Attributes expose ``tonight`` (today's meal
+    dict or ``None``), ``week`` (list of one entry per upcoming day,
+    each with ``date``, ``weekday`` and ``meal``), and
+    ``meal_calendar_entity`` so cards can call ``calendar.create_event``
+    against the right target.
+    """
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "meals"
+
+    def __init__(self, coordinator: DataUpdateCoordinator, conf: dict) -> None:
+        """Store the coordinator and resolved config."""
+        super().__init__(coordinator)
+        self._conf = conf
+        self._attr_unique_id = "familyboard_meals"
+        self._attr_icon = "mdi:silverware-fork-knife"
+        self._attr_device_info = get_device_info()
+
+    def _meals(self) -> list[dict]:
+        """Return the upcoming meals list from the coordinator."""
+        if not self.coordinator.data:
+            return []
+        return self.coordinator.data.get("meals", [])
+
+    def _tonight(self) -> dict | None:
+        """Return today's first meal entry, if any."""
+        today_iso = dt_util.now().date().isoformat()
+        for meal in self._meals():
+            if meal.get("date") == today_iso:
+                return meal
+        return None
+
+    @property
+    def native_value(self) -> str:
+        """Return tonight's meal title or the empty placeholder."""
+        tonight = self._tonight()
+        if tonight and tonight.get("title"):
+            return tonight["title"]
+        return MEAL_PLACEHOLDER
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Expose tonight + the upcoming week as a flat list for cards."""
+        meals_by_date: dict[str, dict] = {}
+        for meal in self._meals():
+            meals_by_date.setdefault(meal["date"], meal)
+
+        today = dt_util.now().date()
+        week: list[dict] = []
+        for offset in range(MEAL_LOOKAHEAD_DAYS):
+            day = today + timedelta(days=offset)
+            iso = day.isoformat()
+            week.append(
+                {
+                    "date": iso,
+                    "weekday": day.strftime("%A"),
+                    "meal": meals_by_date.get(iso),
+                }
+            )
+        return {
+            "tonight": self._tonight(),
+            "week": week,
+            "meal_calendar_entity": self._conf.get("meal_calendar"),
+        }

--- a/custom_components/familyboard/sensor.py
+++ b/custom_components/familyboard/sensor.py
@@ -66,6 +66,7 @@ class FamilyBoardChoresSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._conf = conf
         self._attr_unique_id = "familyboard_chores"
+        self._attr_suggested_object_id = "familyboard_chores"
         self._attr_icon = "mdi:bell-ring"
         self._attr_device_info = get_device_info()
 
@@ -95,6 +96,7 @@ class FamilyBoardComplimentSensor(SensorEntity):
     def __init__(self) -> None:
         """Initialize the compliment sensor."""
         self._attr_unique_id = "familyboard_compliment_integrated"
+        self._attr_suggested_object_id = "familyboard_compliment"
         self._attr_icon = "mdi:hand-wave"
         self._attr_device_info = get_device_info()
 
@@ -126,6 +128,7 @@ class FamilyBoardMembersSensor(CoordinatorEntity, SensorEntity):
         """Store the coordinator reference."""
         super().__init__(coordinator)
         self._attr_unique_id = "familyboard_members"
+        self._attr_suggested_object_id = "familyboard_members"
         self._attr_icon = "mdi:account-group"
         self._attr_device_info = get_device_info()
 
@@ -158,6 +161,7 @@ class FamilyBoardProgressSensor(CoordinatorEntity, SensorEntity):
         """Store the coordinator reference."""
         super().__init__(coordinator)
         self._attr_unique_id = "familyboard_progress"
+        self._attr_suggested_object_id = "familyboard_progress"
         self._attr_icon = "mdi:progress-check"
         self._attr_device_info = get_device_info()
 
@@ -216,6 +220,7 @@ class FamilyBoardMealsSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._conf = conf
         self._attr_unique_id = "familyboard_meals"
+        self._attr_suggested_object_id = "familyboard_meals"
         self._attr_icon = "mdi:silverware-fork-knife"
         self._attr_device_info = get_device_info()
 
@@ -284,6 +289,7 @@ class FamilyBoardRecentMealsSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._conf = conf
         self._attr_unique_id = "familyboard_recent_meals"
+        self._attr_suggested_object_id = "familyboard_recent_meals"
         self._attr_icon = "mdi:history"
         self._attr_device_info = get_device_info()
 

--- a/custom_components/familyboard/services.yaml
+++ b/custom_components/familyboard/services.yaml
@@ -9,6 +9,14 @@ add_event:
     Reads the current entity states, creates the event on the matching
     member calendar, and resets the form.
 
+add_meal:
+  name: Add meal
+  description: >-
+    Create an all-day meal event in the configured meal_calendar from the
+    add-event form entities (text.familyboard_event_title,
+    datetime.familyboard_day_start). Resets the title afterwards. Requires
+    `meal_calendar` to be set in the FamilyBoard options.
+
 snooze_test:
   name: Test snooze reminder
   description: >-

--- a/custom_components/familyboard/text.py
+++ b/custom_components/familyboard/text.py
@@ -27,9 +27,18 @@ async def async_setup_entry(
         icon="mdi:format-title",
         max_value=255,
     )
-    async_add_entities([title], True)
+    countdown_label = FamilyBoardText(
+        unique_id="familyboard_countdown_label",
+        translation_key="countdown_label",
+        icon="mdi:rocket-launch",
+        max_value=80,
+    )
+    async_add_entities([title, countdown_label], True)
     fb = hass.data.setdefault(DOMAIN, {})
-    fb["text"] = {"event_title": title}
+    fb["text"] = {
+        "event_title": title,
+        "countdown_label": countdown_label,
+    }
 
 
 class FamilyBoardText(TextEntity, RestoreEntity):
@@ -44,6 +53,7 @@ class FamilyBoardText(TextEntity, RestoreEntity):
     ) -> None:
         """Initialize the text entity with metadata and an empty value."""
         self._attr_unique_id = unique_id
+        self._attr_suggested_object_id = unique_id
         self._attr_translation_key = translation_key
         self._attr_icon = icon
         self._attr_native_max = max_value

--- a/custom_components/familyboard/translations/en.json
+++ b/custom_components/familyboard/translations/en.json
@@ -118,13 +118,32 @@
       "chores": { "name": "Chores" },
       "compliment": { "name": "Greeting" },
       "meals": { "name": "Meals" },
+      "recent_meals": { "name": "Recent meals" },
       "members": { "name": "Members" },
       "progress": { "name": "Progress" }
     },
+    "binary_sensor": {
+      "meals_unplanned": { "name": "Meals to plan" }
+    },
     "select": {
       "calendar_filter": { "name": "Calendar filter" },
-      "view": { "name": "View" },
-      "layout": { "name": "Layout" },
+      "view": {
+        "name": "View",
+        "state": {
+          "today": "Today",
+          "tomorrow": "Tomorrow",
+          "week": "Week",
+          "two_weeks": "2 Weeks",
+          "month": "Month"
+        }
+      },
+      "layout": {
+        "name": "Layout",
+        "state": {
+          "list": "List",
+          "agenda": "Agenda"
+        }
+      },
       "event_member": { "name": "Event member" },
       "event_calendar": { "name": "Event calendar" }
     },

--- a/custom_components/familyboard/translations/en.json
+++ b/custom_components/familyboard/translations/en.json
@@ -117,6 +117,7 @@
     "sensor": {
       "chores": { "name": "Chores" },
       "compliment": { "name": "Greeting" },
+      "meals": { "name": "Meals" },
       "members": { "name": "Members" },
       "progress": { "name": "Progress" }
     },

--- a/custom_components/familyboard/translations/en.json
+++ b/custom_components/familyboard/translations/en.json
@@ -20,6 +20,7 @@
           "trash": "Trash collections",
           "shared_calendars": "Shared calendars",
           "shared_chores": "Shared chores",
+          "general": "General settings",
           "save": "Save and exit"
         }
       },
@@ -103,6 +104,13 @@
           "color": "Color (hex)",
           "__remove__": "Remove this entry"
         }
+      },
+      "general": {
+        "title": "General settings",
+        "description": "Optional integration-wide settings.",
+        "data": {
+          "meal_calendar": "Meal calendar"
+        }
       }
     },
     "error": {
@@ -152,13 +160,15 @@
       "show_reminders": { "name": "Show reminders" }
     },
     "text": {
-      "event_title": { "name": "Event title" }
+      "event_title": { "name": "Event title" },
+      "countdown_label": { "name": "Countdown label" }
     },
     "datetime": {
       "event_start": { "name": "Event start" },
       "event_end": { "name": "Event end" },
       "day_start": { "name": "Day start" },
-      "day_end": { "name": "Day end" }
+      "day_end": { "name": "Day end" },
+      "countdown_date": { "name": "Countdown date" }
     }
   },
   "services": {

--- a/custom_components/familyboard/translations/nl.json
+++ b/custom_components/familyboard/translations/nl.json
@@ -20,6 +20,7 @@
           "trash": "Afval",
           "shared_calendars": "Gedeelde agenda's",
           "shared_chores": "Gedeelde taken",
+          "general": "Algemene instellingen",
           "save": "Opslaan en sluiten"
         }
       },
@@ -103,6 +104,13 @@
           "color": "Kleur (hex)",
           "__remove__": "Verwijder dit item"
         }
+      },
+      "general": {
+        "title": "Algemene instellingen",
+        "description": "Optionele integratie-brede instellingen.",
+        "data": {
+          "meal_calendar": "Maaltijdenagenda"
+        }
       }
     },
     "error": {
@@ -152,13 +160,15 @@
       "show_reminders": { "name": "Herinneringen tonen" }
     },
     "text": {
-      "event_title": { "name": "Event titel" }
+      "event_title": { "name": "Event titel" },
+      "countdown_label": { "name": "Aftellabel" }
     },
     "datetime": {
       "event_start": { "name": "Event start" },
       "event_end": { "name": "Event einde" },
       "day_start": { "name": "Dag start" },
-      "day_end": { "name": "Dag einde" }
+      "day_end": { "name": "Dag einde" },
+      "countdown_date": { "name": "Afteldatum" }
     }
   },
   "services": {

--- a/custom_components/familyboard/translations/nl.json
+++ b/custom_components/familyboard/translations/nl.json
@@ -118,13 +118,32 @@
       "chores": { "name": "Taken" },
       "compliment": { "name": "Begroeting" },
       "meals": { "name": "Maaltijden" },
+      "recent_meals": { "name": "Recente maaltijden" },
       "members": { "name": "Leden" },
       "progress": { "name": "Voortgang" }
     },
+    "binary_sensor": {
+      "meals_unplanned": { "name": "Maaltijden te plannen" }
+    },
     "select": {
       "calendar_filter": { "name": "Kalenderfilter" },
-      "view": { "name": "Weergave" },
-      "layout": { "name": "Layout" },
+      "view": {
+        "name": "Weergave",
+        "state": {
+          "today": "Vandaag",
+          "tomorrow": "Morgen",
+          "week": "Week",
+          "two_weeks": "2 Weken",
+          "month": "Maand"
+        }
+      },
+      "layout": {
+        "name": "Layout",
+        "state": {
+          "list": "Lijst",
+          "agenda": "Agenda"
+        }
+      },
       "event_member": { "name": "Event wie" },
       "event_calendar": { "name": "Event agenda" }
     },

--- a/custom_components/familyboard/translations/nl.json
+++ b/custom_components/familyboard/translations/nl.json
@@ -117,6 +117,7 @@
     "sensor": {
       "chores": { "name": "Taken" },
       "compliment": { "name": "Begroeting" },
+      "meals": { "name": "Maaltijden" },
       "members": { "name": "Leden" },
       "progress": { "name": "Voortgang" }
     },

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -26,6 +26,9 @@ def test_get_device_info_returns_deviceinfo() -> None:
 def test_view_and_layout_options_are_lists() -> None:
     assert isinstance(VIEW_OPTIONS, list) and VIEW_OPTIONS
     assert isinstance(LAYOUT_OPTIONS, list) and LAYOUT_OPTIONS
+    # Stable, language-neutral keys; user-visible labels live in translations.
+    assert VIEW_OPTIONS == ["today", "tomorrow", "week", "two_weeks", "month"]
+    assert LAYOUT_OPTIONS == ["list", "agenda"]
 
 
 def test_domain_is_familyboard() -> None:

--- a/tests/test_countdown_entities.py
+++ b/tests/test_countdown_entities.py
@@ -1,0 +1,45 @@
+"""Tests for the FR-12 event countdown entities."""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from custom_components.familyboard.const import DOMAIN
+
+
+async def test_countdown_entities_registered(
+    hass: HomeAssistant, sample_config
+) -> None:
+    """The countdown text + datetime entities should be created on setup."""
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: sample_config})
+    await hass.async_block_till_done()
+
+    ent_reg = er.async_get(hass)
+
+    label_id = ent_reg.async_get_entity_id(
+        "text", DOMAIN, "familyboard_countdown_label"
+    )
+    assert label_id is not None, "countdown label text entity not registered"
+    label_entry = ent_reg.async_get(label_id)
+    assert label_entry is not None
+    assert label_entry.translation_key == "countdown_label"
+
+    label_state = hass.states.get(label_id)
+    assert label_state is not None
+    # Empty by default so the card stays hidden until the user sets one.
+    assert label_state.state == ""
+
+    date_id = ent_reg.async_get_entity_id(
+        "datetime", DOMAIN, "familyboard_countdown_date"
+    )
+    assert date_id is not None, "countdown date entity not registered"
+    date_entry = ent_reg.async_get(date_id)
+    assert date_entry is not None
+    assert date_entry.translation_key == "countdown_date"
+
+    date_state = hass.states.get(date_id)
+    assert date_state is not None
+    # Default is roughly today + 7d; just confirm it's a parseable datetime.
+    assert date_state.state not in ("", "unknown", "unavailable")

--- a/tests/test_meals_sensor.py
+++ b/tests/test_meals_sensor.py
@@ -1,0 +1,76 @@
+"""Tests for FamilyBoardMealsSensor."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+from homeassistant.util import dt as dt_util
+
+from custom_components.familyboard.const import MEAL_LOOKAHEAD_DAYS, MEAL_PLACEHOLDER
+from custom_components.familyboard.sensor import FamilyBoardMealsSensor
+
+
+def _make_sensor(
+    meals: list[dict], meal_calendar: str | None
+) -> FamilyBoardMealsSensor:
+    """Build a meals sensor with a stubbed coordinator."""
+    coordinator = MagicMock()
+    coordinator.data = {"meals": meals}
+    coordinator.last_update_success = True
+    return FamilyBoardMealsSensor(coordinator, {"meal_calendar": meal_calendar})
+
+
+def test_meals_sensor_empty_returns_placeholder() -> None:
+    """No meals + no calendar configured → placeholder state, empty week."""
+    sensor = _make_sensor([], None)
+    assert sensor.native_value == MEAL_PLACEHOLDER
+    attrs = sensor.extra_state_attributes
+    assert attrs["tonight"] is None
+    assert attrs["meal_calendar_entity"] is None
+    assert len(attrs["week"]) == MEAL_LOOKAHEAD_DAYS
+    assert all(day["meal"] is None for day in attrs["week"])
+
+
+def test_meals_sensor_today_meal_surfaces() -> None:
+    """Meal scheduled for today → state matches title and tonight populated."""
+    today = dt_util.now().date().isoformat()
+    meals = [
+        {
+            "date": today,
+            "title": "Pasta bolognese",
+            "start": f"{today}T18:00:00",
+            "end": f"{today}T19:00:00",
+            "description": "",
+            "uid": "meal-1",
+            "all_day": False,
+        }
+    ]
+    sensor = _make_sensor(meals, "calendar.meals")
+    assert sensor.native_value == "Pasta bolognese"
+    attrs = sensor.extra_state_attributes
+    assert attrs["tonight"]["title"] == "Pasta bolognese"
+    assert attrs["meal_calendar_entity"] == "calendar.meals"
+    assert attrs["week"][0]["meal"]["title"] == "Pasta bolognese"
+
+
+def test_meals_sensor_future_meal_no_tonight() -> None:
+    """Future-only meal → state placeholder, week entry populated on right day."""
+    tomorrow = (dt_util.now().date() + timedelta(days=2)).isoformat()
+    meals = [
+        {
+            "date": tomorrow,
+            "title": "Stamppot",
+            "start": f"{tomorrow}T18:00:00",
+            "end": f"{tomorrow}T19:00:00",
+            "description": "",
+            "uid": "meal-2",
+            "all_day": False,
+        }
+    ]
+    sensor = _make_sensor(meals, "calendar.meals")
+    assert sensor.native_value == MEAL_PLACEHOLDER
+    attrs = sensor.extra_state_attributes
+    assert attrs["tonight"] is None
+    matching = [day for day in attrs["week"] if day["date"] == tomorrow]
+    assert matching and matching[0]["meal"]["title"] == "Stamppot"

--- a/tests/test_recent_meals.py
+++ b/tests/test_recent_meals.py
@@ -1,0 +1,117 @@
+"""Tests for the recent-meals scoring helper and binary sensor."""
+
+from __future__ import annotations
+
+from datetime import date as _date, timedelta
+from unittest.mock import MagicMock
+
+from homeassistant.util import dt as dt_util
+
+from custom_components.familyboard.binary_sensor import (
+    FamilyBoardMealsUnplannedBinarySensor,
+)
+from custom_components.familyboard.const import MEAL_LOOKAHEAD_DAYS
+from custom_components.familyboard.helpers import (
+    is_meal_placeholder,
+    meal_penalty,
+    score_recent_meals,
+)
+
+
+def test_is_meal_placeholder_recognises_skips() -> None:
+    """Placeholder titles are detected case-insensitively."""
+    assert is_meal_placeholder("")
+    assert is_meal_placeholder("-")
+    assert is_meal_placeholder("Geen")
+    assert is_meal_placeholder("none")
+    assert not is_meal_placeholder("Pasta")
+
+
+def test_meal_penalty_anchors_and_interpolation() -> None:
+    """Penalty matches anchors and interpolates linearly between them."""
+    assert meal_penalty(0) == 10.0
+    assert meal_penalty(3) == 6.0
+    assert meal_penalty(7) == 3.0
+    assert meal_penalty(14) == 1.0
+    assert meal_penalty(30) == 0.0
+    # Interpolation: midway between (7, 3.0) and (14, 1.0) at d=10.5 → 2.0.
+    assert abs(meal_penalty(10) - (3.0 + (1.0 - 3.0) * (10 - 7) / (14 - 7))) < 1e-9
+
+
+def test_score_recent_meals_skips_placeholders_and_dedups() -> None:
+    """Dedup case-insensitive; placeholders excluded; sorted by score."""
+    today = _date(2026, 4, 20)
+    events = [
+        {"title": "Pasta", "date": "2026-04-19"},
+        {"title": "pasta", "date": "2026-04-15"},
+        {"title": "Pasta", "date": "2026-03-10"},
+        {"title": "Stamppot", "date": "2026-04-05"},
+        {"title": "Stamppot", "date": "2026-03-20"},
+        {"title": "Stamppot", "date": "2026-03-01"},
+        {"title": "geen", "date": "2026-04-18"},
+        {"title": "-", "date": "2026-04-17"},
+    ]
+    items = score_recent_meals(events, today)
+    titles = [i["title"] for i in items]
+    # Only Pasta + Stamppot remain (placeholders skipped).
+    assert set(titles) == {"Pasta", "Stamppot"}
+    # Stamppot: 3 uses, last 15d ago → score 3 - ~0.71 ≈ 2.29.
+    # Pasta:    3 uses, last 1d ago  → score 3 - ~7.33 ≈ -4.33.
+    # Stamppot should outrank Pasta thanks to recency penalty.
+    assert items[0]["title"] == "Stamppot"
+
+
+def _make_binary_sensor(meals: list[dict]) -> FamilyBoardMealsUnplannedBinarySensor:
+    """Build the unplanned-meals binary sensor with a stubbed coordinator."""
+    coordinator = MagicMock()
+    coordinator.data = {"meals": meals}
+    coordinator.last_update_success = True
+    return FamilyBoardMealsUnplannedBinarySensor(coordinator)
+
+
+def test_meals_unplanned_on_when_window_has_gaps() -> None:
+    """Empty meals → on, all upcoming dates listed."""
+    sensor = _make_binary_sensor([])
+    assert sensor.is_on is True
+    attrs = sensor.extra_state_attributes
+    assert attrs["count"] == MEAL_LOOKAHEAD_DAYS
+    assert attrs["next_unplanned"] == dt_util.now().date().isoformat()
+
+
+def test_meals_unplanned_off_when_every_day_covered() -> None:
+    """Every upcoming day has either a real or skipped event → off."""
+    today = dt_util.now().date()
+    meals = [
+        {
+            "date": (today + timedelta(days=offset)).isoformat(),
+            "title": "Stamppot" if offset % 2 == 0 else "geen",
+            "start": (today + timedelta(days=offset)).isoformat(),
+            "end": (today + timedelta(days=offset)).isoformat(),
+            "all_day": True,
+            "status": "planned" if offset % 2 == 0 else "skipped",
+        }
+        for offset in range(MEAL_LOOKAHEAD_DAYS)
+    ]
+    sensor = _make_binary_sensor(meals)
+    assert sensor.is_on is False
+    assert sensor.extra_state_attributes["count"] == 0
+
+
+def test_meals_unplanned_skipped_counts_as_planned() -> None:
+    """Even a skipped placeholder removes the day from the gap list."""
+    today = dt_util.now().date()
+    meals = [
+        {
+            "date": today.isoformat(),
+            "title": "geen",
+            "start": today.isoformat(),
+            "end": today.isoformat(),
+            "all_day": True,
+            "status": "skipped",
+        }
+    ]
+    sensor = _make_binary_sensor(meals)
+    attrs = sensor.extra_state_attributes
+    # Today is covered (skipped); only days 1..6 are unplanned.
+    assert today.isoformat() not in attrs["unplanned_dates"]
+    assert attrs["count"] == MEAL_LOOKAHEAD_DAYS - 1


### PR DESCRIPTION
## Summary

Bundles four cohesive changes that grew on `feature/meal`:

1. **Meal planning (Phase 1 + 2)** — `meal_calendar` config key,
   `sensor.familyboard_meals` (tonight + 7-day week),
   `binary_sensor.familyboard_meals_unplanned` (problem class),
   placeholder titles (`-`, `?`, `geen`, …) that count as planned-but-skipped,
   and `sensor.familyboard_recent_meals` scoring the last 90 days
   (`uses − recency_penalty`, top 12) feeding a Bubble Card meal-picker
   popup on the dashboard.
2. **i18n cleanup of select states** — `select.familyboard_view`
   (`today`/`tomorrow`/`week`/`two_weeks`/`month`) and
   `select.familyboard_layout` (`list`/`agenda`) now use stable English keys.
   User-visible labels live in `translations/{en,nl}.json` under
   `entity.select.{view,layout}.state.*`. Existing Dutch states are
   migrated automatically on `RestoreEntity` load via
   `LEGACY_*_STATE_MAP`, so this is non-breaking for current installs.
3. **New `custom:familyboard-view-card`** — wraps `mushroom-chips-card`,
   reads option list from any FamilyBoard select entity, and resolves
   labels via `hass.formatEntityState`. Dashboards (`familyboard.yaml`,
   `tasks.yaml`) and the `familyboard-strategy` no longer hand-build
   ~70 lines of inline mushroom chips per chip-row; they delegate to
   this card.
4. **Visual editors for every FamilyBoard card** — `progress`,
   `chores`, `calendar`, `filter`, `view` now expose
   `getConfigElement()` / `getStubConfig()` returning a tiny
   `ha-form`-driven editor. The "Visuele editor niet ondersteund"
   notice in the dashboard card picker is gone.

Plus: card console banners now report `<manifest-version>-<short-hash>`
(read from `manifest.json` at registration time) instead of a hardcoded
string.

## Migration notes

- **Non-breaking for existing installs** — restored Dutch select states
  (`Vandaag`, `Lijst`, …) are mapped to the new English keys on first
  load.
- No config-schema additions are required; `meal_calendar` is optional.
- Dict-typed card options (`colors`, `names`, `filter_map`,
  `shared_calendars`, `member_entities`, `icons`, `extra_chips`) stay
  YAML-only — visual editors expose only the simple keys.

## Verification

- `ruff check` + `ruff format --check` — clean.
- `python -m compileall custom_components/familyboard tests` — clean.
- `node --check` on all 6 frontend JS files — clean.
- `pytest` — green in dev container (local venv is Py<3.11, runs in CI).
- Manual dev-container walk-through of: meal sensors, chip selectors
  (NL + EN), card editor for each `custom:familyboard-*-card`.

## Files changed

~1.4k LOC across coordinator, sensors, cards, translations, dashboards,
tests. See diff stat for breakdown.

## Out of scope

- No dedicated `familyboard-meal-card` (Vanavond/week-strip stays in
  dashboard YAML for now).
- README "Lovelace cards" section not yet noting editor support — to
  follow in a small docs PR.