### PR TITLE
chore: README polish + warn on missing Bubble Card

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,42 @@ a unified family dashboard with reusable Lovelace cards.
 
 ![FamilyBoard dashboard screenshot](docs/screenshot.png)
 
+> Screenshot is anonymized (PII removed) and the empty cells were
+> demo-filled with [Gemini Nano Banana](https://gemini.google.com/) so
+> the layout reads at a glance.
+
+## Why
+
+My family is like most households: we struggle with the same small questions every single day. *What’s happening this afternoon? What are we eating? Whose turn is it to take out the trash?* When you factor in **ADHD**, these questions aren't just trivial—they are obstacles. For my family members, "out of sight" literally means "out of mind." Cluttered phone apps, hidden notifications, and fragmented calendars create a constant mental tax.
+
+**I built FamilyBoard together with my family** to serve as an **external brain** for our home. Because we designed it as a team, every feature is tuned to how we actually live. It moves the "Status Update" fatigue away from shouting across the kitchen and into a calm, persistent display on the wall. 
+
+It is designed for:
+* **Visual Persistence:** Keeping chores and events visible so they don't disappear from the mind (supporting object permanence).
+* **Predictability:** Surfacing trash days and meal plans before the "what now?" panic sets in.
+* **Cognitive Ease:** A zero-scroll, zero-tap interface that passes the **"Glance Test"**—if you can't see the answer while walking past the tablet with a laundry basket, the UI has failed.
+
+FamilyBoard doesn't ask my family to change how they function; it changes the environment to better support how they think.
+
+## How it works
+
+- **Bring your own calendar and tasks.** Put events in whatever
+  calendar app you already use (Google, iCloud, CalDAV) and chores in
+  whatever to-do list you already use (Google Tasks, Microsoft To Do, a
+  local HA `todo`). Sync them into Home Assistant once —
+  bidirectionally if you want — and FamilyBoard reads from there. No
+  second place to manage anything.
+- **One unified overview.** Per-member calendars, shared family
+  calendars, trash collection, chores and reminders are merged into a
+  single screen. Filter on the fly: just one person, just today, just
+  chores, hide reminders that are already shown elsewhere.
+- **Reminders live where you want them.** Tasks can render inside the
+  calendar grid as time-blocks, or outside it as a separate reminders
+  list — toggleable per dashboard so you don't see the same item twice.
+- **Native HA only.** No `input_*` helpers, no custom storage backend.
+  Everything is a `select` / `text` / `switch` / `datetime` entity with
+  proper restore-state and config-flow support.
+
 ## Features
 
 - **Per-member calendar proxies** — primary + extra calendars, Google Tasks filtered out automatically.

--- a/README.md
+++ b/README.md
@@ -296,11 +296,10 @@ members_entity: sensor.familyboard_members
 
 ## Dashboard options
 
-There are three ways to use FamilyBoard in your dashboards:
+There are two ways to use FamilyBoard in your dashboards:
 
 1. **Compose your own** — add the cards listed above into any dashboard, any view, any layout. The cards are independent; mix freely with core/HACS cards.
-2. **Static template** — `dashboards/familyboard.yaml` in this repo provides a curated full layout. Reference it from `configuration.yaml` under `lovelace.dashboards`.
-3. **Dashboard strategy** — `strategy: type: custom:familyboard` auto-generates a sections-view dashboard from the current members, chores and calendars sensors. Add or remove a member and the dashboard updates automatically. "Take Control" in the UI converts the generated layout back into editable YAML for further tweaking.
+2. **Dashboard strategy** — `strategy: type: custom:familyboard` auto-generates a sections-view dashboard from the current members, chores and calendars sensors. Add or remove a member and the dashboard updates automatically. "Take Control" in the UI converts the generated layout back into editable YAML for further tweaking.
 
 ### Strategy example
 
@@ -344,10 +343,15 @@ is fully optional — the cards work with any theme.
 
 ## Dependencies
 
-Required HACS frontend resources (the integration warns if missing):
+The FamilyBoard cards themselves are self-contained, but the bundled
+dashboard strategy (`strategy: custom:familyboard`) renders a few
+third-party cards. Install these from HACS — the integration logs a
+warning and posts a persistent notification if any are missing:
 
 - [Mushroom Cards](https://github.com/piitaya/lovelace-mushroom)
 - [card-mod](https://github.com/thomasloven/lovelace-card-mod)
+- [Bubble Card](https://github.com/Clooos/Bubble-Card) — used for the
+  *Add event* and *Meal picker* pop-ups.
 
 ## Development
 

--- a/custom_components/familyboard/__init__.py
+++ b/custom_components/familyboard/__init__.py
@@ -356,8 +356,12 @@ async def _async_sync_lovelace_resources(hass: HomeAssistant) -> None:
 
 
 async def _async_check_lovelace_dependencies(hass: HomeAssistant) -> None:
-    """Warn if required HACS frontend deps (mushroom, card-mod) are missing."""
-    required = {"mushroom": "Mushroom Cards", "card-mod": "card-mod"}
+    """Warn if required HACS frontend deps (mushroom, card-mod, bubble) are missing."""
+    required = {
+        "mushroom": "Mushroom Cards",
+        "card-mod": "card-mod",
+        "bubble-card": "Bubble Card",
+    }
     found: set[str] = set()
 
     lovelace_data = hass.data.get("lovelace")


### PR DESCRIPTION
## Summary

Small follow-ups to the v0.1.0 release.

### README
- Drop the reference to \`dashboards/familyboard.yaml\` from the *Dashboard options* section. That file is gitignored and not shipped, so the previous "static template" option misled users. The dashboard strategy (\`custom:familyboard\`) is now listed as the only bundled option alongside hand-composed dashboards.
- Clarify in *Dependencies* that the integration logs a warning **and** posts a persistent notification when a required HACS frontend resource is missing.

### Integration
- Extend \`_async_check_lovelace_dependencies\` to include **Bubble Card** alongside Mushroom and card-mod. Bubble Card is used by the strategy for the *Add event* and *Meal picker* pop-ups, so missing it is a real visible breakage.

## Test plan
- \`ruff check\` / \`ruff format --check\` clean.
- Manual: with Bubble Card uninstalled, integration setup logs the warning and creates a persistent notification listing it. With it installed, no warning.