### PR TITLE
feat: add new calendar views and enhance event rendering in FamilyBoard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Native month view in `familyboard-calendar-card` (replaces the Phase 3
-  placeholder): 6×7 grid, max 3 event pills per cell with `+N meer` overflow,
-  multi-member gradient pills, weather badge, today/other-month/weekend
-  styling.
+  placeholder): 6×7 grid with multi-member gradient pills, weather badge and
+  today/other-month/weekend styling. Week rows grow to fit all events — no
+  more `+N meer` overflow truncation.
+- `familyboard-calendar-card`: `show_navigation: false` now actually hides
+  the prev/today/next buttons in the card header.
 - Multi-day events render as continuous bars across the month grid (Google
   Calendar style), with `‹` / `›` arrows on segments that continue into the
   previous or next week.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Native month view in `familyboard-calendar-card` (replaces the Phase 3
+  placeholder): 6×7 grid, max 3 event pills per cell with `+N meer` overflow,
+  multi-member gradient pills, weather badge, today/other-month/weekend
+  styling.
+- Multi-day events render as continuous bars across the month grid (Google
+  Calendar style), with `‹` / `›` arrows on segments that continue into the
+  previous or next week.
+- New view options: `today_tomorrow` (today + tomorrow side-by-side) and
+  `work_week` (Mon–Fri of current week). Wired through the calendar card,
+  chores card, list-mode strategy and translations (NL/EN).
+- Week start in `familyboard-calendar-card` now follows the HA user profile
+  (`hass.locale.firstWeekday`) for week, two-weeks and month grid headers.
+  Werkweek blijft altijd ma–vr.
+- `familyboard-view-card` accepts `hidden_options:` and `visible_options:`
+  to hide/whitelist chips per dashboard without touching the select entity.
+
 ## [0.1.0] - 2026-04-23
 
 Initial public release.

--- a/custom_components/familyboard/__init__.py
+++ b/custom_components/familyboard/__init__.py
@@ -664,8 +664,15 @@ class FamilyBoardCoordinator(DataUpdateCoordinator):
             return (today.isoformat(), today.isoformat())
         if view == "tomorrow":
             return (today.isoformat(), (today + timedelta(days=1)).isoformat())
+        if view == "today_tomorrow":
+            return (today.isoformat(), (today + timedelta(days=1)).isoformat())
         if view == "week":
             return (today.isoformat(), (today + timedelta(days=7)).isoformat())
+        if view == "work_week":
+            # Mon..Fri of the current week (Mon = 0)
+            monday = today - timedelta(days=today.weekday())
+            friday = monday + timedelta(days=4)
+            return (monday.isoformat(), friday.isoformat())
         if view == "two_weeks":
             return (today.isoformat(), (today + timedelta(days=14)).isoformat())
         if view == "month":

--- a/custom_components/familyboard/const.py
+++ b/custom_components/familyboard/const.py
@@ -59,7 +59,15 @@ SNOOZE_MAX_MIN = 240
 
 # View / filter options. Stable, language-neutral keys; user-visible labels
 # come from translations (entity.select.<key>.state.<key>).
-VIEW_OPTIONS = ["today", "tomorrow", "week", "two_weeks", "month"]
+VIEW_OPTIONS = [
+    "today",
+    "tomorrow",
+    "today_tomorrow",
+    "week",
+    "work_week",
+    "two_weeks",
+    "month",
+]
 LAYOUT_OPTIONS = ["list", "agenda"]
 ALLES = "Alles"
 # Legacy Dutch state values from earlier releases — restored states are mapped

--- a/custom_components/familyboard/frontend/familyboard-calendar-card.js
+++ b/custom_components/familyboard/frontend/familyboard-calendar-card.js
@@ -38,14 +38,33 @@
  */
 
 const DEFAULT_COLORS = ["#4A90D9", "#27AE60", "#F39C12", "#9B59B6", "#E74C3C", "#1ABC9C"];
-const VIEW_NL = { day: "Vandaag", week: "Week", "2weeks": "2 Weken", month: "Maand" };
+const VIEW_NL = {
+  day: "Vandaag",
+  "2days": "Vandaag + Morgen",
+  week: "Week",
+  workweek: "Werkweek",
+  "2weeks": "2 Weken",
+  month: "Maand",
+};
 // Map stable select-state keys to internal view modes.
 const VIEW_FROM_SELECT = {
   today: "day",
   tomorrow: "day",
+  today_tomorrow: "2days",
   week: "week",
+  work_week: "workweek",
   two_weeks: "2weeks",
   month: "month",
+};
+// firstWeekday string -> day index (0 = Sunday)
+const FIRST_WEEKDAY_MAP = {
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
+  sunday: 0,
 };
 
 class FamilyBoardCalendarCard extends HTMLElement {
@@ -147,18 +166,34 @@ class FamilyBoardCalendarCard extends HTMLElement {
 
   _anchorCurrentStartFor(viewSelectState) {
     const today = this._startOfDay(new Date());
-    if (viewSelectState === "today") {
+    if (viewSelectState === "today" || viewSelectState === "today_tomorrow") {
       this._currentStart = today;
     } else if (viewSelectState === "tomorrow") {
       this._currentStart = this._addDays(today, 1);
     } else if (viewSelectState === "week" || viewSelectState === "two_weeks") {
-      // snap to monday of current week
+      // snap to first weekday of current week (HA locale)
+      const fw = this._firstWeekday();
+      const dow = (today.getDay() - fw + 7) % 7;
+      this._currentStart = this._addDays(today, -dow);
+    } else if (viewSelectState === "work_week") {
+      // always snap to Monday of current week
       const dow = (today.getDay() + 6) % 7; // Mon=0
       this._currentStart = this._addDays(today, -dow);
     } else if (viewSelectState === "month") {
       this._currentStart = new Date(today.getFullYear(), today.getMonth(), 1);
     }
     this._fetchKey = null;
+  }
+
+  // First day of week index (0=Sun..6=Sat) from HA user locale; fallback Monday.
+  _firstWeekday() {
+    const fw = this._hass?.locale?.firstWeekday;
+    if (typeof fw === "number" && fw >= 0 && fw <= 6) return fw;
+    if (typeof fw === "string") {
+      const v = FIRST_WEEKDAY_MAP[fw.toLowerCase()];
+      if (v !== undefined) return v;
+    }
+    return 1; // Monday default
   }
 
   getCardSize() {
@@ -363,12 +398,15 @@ class FamilyBoardCalendarCard extends HTMLElement {
     const start = new Date(this._currentStart);
     let end;
     if (view === "day") end = this._addDays(start, 1);
+    else if (view === "2days") end = this._addDays(start, 2);
+    else if (view === "workweek") end = this._addDays(start, 5);
     else if (view === "week") end = this._addDays(start, 7);
     else if (view === "2weeks") end = this._addDays(start, 14);
     else if (view === "month") {
-      // month grid: align to monday before 1st of month, 6 weeks
+      // month grid: align to first weekday before 1st of month, 6 weeks
       const first = new Date(start.getFullYear(), start.getMonth(), 1);
-      const dow = (first.getDay() + 6) % 7; // Mon=0
+      const fw = this._firstWeekday();
+      const dow = (first.getDay() - fw + 7) % 7;
       const gridStart = this._addDays(first, -dow);
       return [gridStart, this._addDays(gridStart, 42)];
     } else {
@@ -601,12 +639,18 @@ class FamilyBoardCalendarCard extends HTMLElement {
 
   _navPrev() {
     const view = this._activeView();
-    const step = view === "day" ? 1 : view === "week" ? 7 : view === "2weeks" ? 14 : 30;
     if (view === "month") {
       const d = new Date(this._currentStart);
       d.setMonth(d.getMonth() - 1);
       this._currentStart = this._startOfDay(d);
     } else {
+      const step =
+        view === "day" ? 1
+        : view === "2days" ? 2
+        : view === "workweek" ? 7
+        : view === "week" ? 7
+        : view === "2weeks" ? 14
+        : 1;
       this._currentStart = this._addDays(this._currentStart, -step);
     }
     this._fetchKey = null;
@@ -616,12 +660,18 @@ class FamilyBoardCalendarCard extends HTMLElement {
 
   _navNext() {
     const view = this._activeView();
-    const step = view === "day" ? 1 : view === "week" ? 7 : view === "2weeks" ? 14 : 30;
     if (view === "month") {
       const d = new Date(this._currentStart);
       d.setMonth(d.getMonth() + 1);
       this._currentStart = this._startOfDay(d);
     } else {
+      const step =
+        view === "day" ? 1
+        : view === "2days" ? 2
+        : view === "workweek" ? 7
+        : view === "week" ? 7
+        : view === "2weeks" ? 14
+        : 1;
       this._currentStart = this._addDays(this._currentStart, step);
     }
     this._fetchKey = null;
@@ -676,12 +726,16 @@ class FamilyBoardCalendarCard extends HTMLElement {
 
     if (view === "day") {
       body.innerHTML = this._renderTimeGrid(1);
+    } else if (view === "2days") {
+      body.innerHTML = this._renderTimeGrid(2);
+    } else if (view === "workweek") {
+      body.innerHTML = this._renderTimeGrid(5);
     } else if (view === "week") {
       body.innerHTML = this._renderTimeGrid(7);
     } else if (view === "2weeks") {
       body.innerHTML = this._renderTimeGrid(14);
     } else if (view === "month") {
-      body.innerHTML = this._renderMonthPlaceholder();
+      body.innerHTML = this._renderMonthGrid();
     }
     this._wireEventClicks();
     this._scrollToHour();
@@ -741,6 +795,8 @@ class FamilyBoardCalendarCard extends HTMLElement {
         grid-template-columns: 56px 1fr;
         position: relative;
       }
+      .fb-grid.cols-2 { grid-template-columns: 56px repeat(2, 1fr); }
+      .fb-grid.cols-5 { grid-template-columns: 56px repeat(5, 1fr); }
       .fb-grid.cols-7 { grid-template-columns: 56px repeat(7, 1fr); }
       .fb-grid.cols-14 { grid-template-columns: 56px repeat(14, minmax(60px, 1fr)); overflow-x: auto; }
 
@@ -919,6 +975,95 @@ class FamilyBoardCalendarCard extends HTMLElement {
         color: var(--fb-muted);
       }
 
+      .fb-month-dow {
+        display: grid;
+        grid-template-columns: repeat(7, minmax(0, 1fr));
+        position: sticky; top: 0; z-index: 3;
+        background: var(--card-background-color, var(--ha-card-background, #1c1c1c));
+        border-bottom: 1px solid var(--fb-border);
+      }
+      .fb-mc-dow {
+        text-align: center;
+        font-size: 0.78em;
+        color: var(--fb-muted);
+        padding: 6px 4px;
+      }
+      .fb-month-grid {
+        display: flex;
+        flex-direction: column;
+      }
+      .fb-month-week {
+        display: grid;
+        grid-template-columns: repeat(7, minmax(0, 1fr));
+        grid-template-rows: 24px repeat(3, 18px) 14px;
+        position: relative;
+        border-bottom: 1px solid var(--fb-border);
+      }
+      .fb-month-week:last-child { border-bottom: none; }
+      .fb-mc-bg {
+        grid-row: 1 / -1;
+        border-right: 1px solid var(--fb-border);
+        z-index: 0;
+      }
+      .fb-mc-bg:nth-child(7n) { border-right: none; }
+      .fb-mc-bg.fb-mc-other { background: var(--fb-bg-alt); }
+      .fb-mc-bg.fb-mc-weekend:not(.fb-mc-other) { background: rgba(255,255,255,0.02); }
+      .fb-mc-bg.fb-mc-today {
+        background: color-mix(in srgb, var(--primary-color) 10%, transparent);
+      }
+      .fb-mc-head {
+        grid-row: 1;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 2px 4px;
+        font-size: 0.82em;
+        line-height: 1.2;
+        z-index: 1;
+        pointer-events: none;
+      }
+      .fb-mc-head.fb-mc-today .fb-mc-num {
+        background: var(--primary-color);
+        color: var(--text-primary-color, #fff);
+        border-radius: 999px;
+        padding: 0 6px;
+        font-weight: 600;
+      }
+      .fb-mc-num {
+        display: inline-block;
+        min-width: 18px;
+        text-align: center;
+      }
+      .fb-mc-head .fb-day-wx {
+        font-size: 0.85em;
+        opacity: 0.85;
+      }
+      .fb-mc-bar {
+        margin: 0 2px;
+        padding: 0 5px;
+        font-size: 0.7em;
+        line-height: 16px;
+        height: 16px;
+        border-radius: 3px;
+        color: #fff;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        cursor: pointer;
+        z-index: 1;
+      }
+      .fb-mc-bar.fb-mc-cont-prev { border-top-left-radius: 0; border-bottom-left-radius: 0; margin-left: 0; }
+      .fb-mc-bar.fb-mc-cont-next { border-top-right-radius: 0; border-bottom-right-radius: 0; margin-right: 0; }
+      .fb-mc-more {
+        grid-row: 5;
+        font-size: 0.65em;
+        color: var(--fb-muted);
+        padding: 0 4px;
+        text-align: left;
+        z-index: 1;
+        pointer-events: none;
+      }
+
       .fb-empty {
         padding: 30px;
         text-align: center;
@@ -952,8 +1097,12 @@ class FamilyBoardCalendarCard extends HTMLElement {
     if (view === "day") {
       return this._formatDate(start, { weekday: "long", day: "numeric", month: "long", year: "numeric" });
     }
-    if (view === "week" || view === "2weeks") {
-      const len = view === "week" ? 6 : 13;
+    if (view === "2days" || view === "workweek" || view === "week" || view === "2weeks") {
+      const len =
+        view === "2days" ? 1
+        : view === "workweek" ? 4
+        : view === "week" ? 6
+        : 13;
       const end = this._addDays(start, len);
       const sm = start.toLocaleDateString(this._config.locale, { day: "numeric", month: "short" });
       const em = end.toLocaleDateString(this._config.locale, { day: "numeric", month: "short", year: "numeric" });
@@ -1021,7 +1170,12 @@ class FamilyBoardCalendarCard extends HTMLElement {
     const totalHours = endHour - startHour;
     const gridHeight = totalHours * hourHeight;
 
-    const colsClass = numDays === 7 ? " cols-7" : numDays === 14 ? " cols-14" : "";
+    const colsClass =
+      numDays === 2 ? " cols-2"
+      : numDays === 5 ? " cols-5"
+      : numDays === 7 ? " cols-7"
+      : numDays === 14 ? " cols-14"
+      : "";
 
     // Header row + all-day row
     let dayHeaders = `<div class="fb-day-header" style="border-right:1px solid var(--fb-border);"></div>`;
@@ -1140,8 +1294,164 @@ class FamilyBoardCalendarCard extends HTMLElement {
     return out;
   }
 
-  _renderMonthPlaceholder() {
-    return `<div class="fb-month-placeholder">Maand-weergave komt in Phase 3.</div>`;
+  _renderMonthGrid() {
+    const cfg = this._config;
+    const today = this._startOfDay(new Date());
+    const monthIdx = this._currentStart.getMonth();
+    const [gridStart] = this._visibleRange();
+
+    const days = [];
+    for (let i = 0; i < 42; i++) days.push(this._addDays(gridStart, i));
+
+    // Combine calendar events with reminder pseudo-events
+    const reminderEvents = this._buildReminderEvents();
+    const allEvents = [...this._events, ...reminderEvents];
+
+    // Weekday header row, starting at firstWeekday
+    let dowHeader = "";
+    for (let i = 0; i < 7; i++) {
+      const sample = this._addDays(gridStart, i);
+      const label = sample.toLocaleDateString(cfg.locale, { weekday: "short" });
+      dowHeader += `<div class="fb-mc-dow">${this._escape(label)}</div>`;
+    }
+
+    const MAX_SLOTS = 3; // visible event rows per week
+    let weeksHtml = "";
+    for (let w = 0; w < 6; w++) {
+      const weekStart = days[w * 7];
+      const weekEnd = this._addDays(weekStart, 7); // exclusive
+
+      // Build segments: one per (event × week) overlap, with span 1..7
+      const segments = [];
+      for (const ev of allEvents) {
+        if (!(ev.endDate > weekStart && ev.startDate < weekEnd)) continue;
+        const segStart = ev.startDate < weekStart ? weekStart : this._startOfDay(ev.startDate);
+        // For all-day events endDate is exclusive midnight.
+        // For timed events ending mid-day, the segment ends on that day.
+        const lastDayCandidate = new Date(ev.endDate.getTime() - 1);
+        const segLast = lastDayCandidate >= weekEnd
+          ? this._addDays(weekEnd, -1)
+          : this._startOfDay(lastDayCandidate);
+        const startDow = Math.round((segStart - weekStart) / 86400000);
+        const span = Math.round((segLast - segStart) / 86400000) + 1;
+        if (span < 1) continue;
+        const isContinuationFromPrev = ev.startDate < weekStart;
+        const isContinuationToNext = ev.endDate > weekEnd;
+        segments.push({
+          ev,
+          startDow: Math.max(0, startDow),
+          span: Math.min(7 - Math.max(0, startDow), span),
+          isContPrev: isContinuationFromPrev,
+          isContNext: isContinuationToNext,
+        });
+      }
+
+      // Sort: longer spans first, then earlier start, all-day before timed
+      segments.sort((a, b) => {
+        const ad = a.ev.allDay || this._spansFullDay(a.ev, weekStart) ? 0 : 1;
+        const bd = b.ev.allDay || this._spansFullDay(b.ev, weekStart) ? 0 : 1;
+        if (ad !== bd) return ad - bd;
+        if (b.span !== a.span) return b.span - a.span;
+        return a.ev.startDate - b.ev.startDate;
+      });
+
+      // Greedy slot assignment: lowest free slot for the segment's columns
+      const used = new Set(); // "dow|slot"
+      const placed = [];
+      for (const seg of segments) {
+        let s = 0;
+        // safety cap to avoid runaway
+        while (s < 32) {
+          let ok = true;
+          for (let d = seg.startDow; d < seg.startDow + seg.span; d++) {
+            if (used.has(`${d}|${s}`)) { ok = false; break; }
+          }
+          if (ok) break;
+          s++;
+        }
+        for (let d = seg.startDow; d < seg.startDow + seg.span; d++) {
+          used.add(`${d}|${s}`);
+        }
+        placed.push({ ...seg, slot: s });
+      }
+
+      // Background day cells (row 1 / -1, full week-row height)
+      let bgs = "";
+      let heads = "";
+      for (let dow = 0; dow < 7; dow++) {
+        const d = days[w * 7 + dow];
+        const isToday = this._isSameDay(d, today);
+        const isOther = d.getMonth() !== monthIdx;
+        const isWeekend = d.getDay() === 0 || d.getDay() === 6;
+        const bgClasses = [
+          "fb-mc-bg",
+          isToday ? "fb-mc-today" : "",
+          isOther ? "fb-mc-other" : "",
+          isWeekend ? "fb-mc-weekend" : "",
+        ].filter(Boolean).join(" ");
+        bgs += `<div class="${bgClasses}" style="grid-column:${dow + 1};"></div>`;
+        const wx = this._renderWeather(d);
+        const headClasses = ["fb-mc-head", isToday ? "fb-mc-today" : ""].filter(Boolean).join(" ");
+        heads += `<div class="${headClasses}" style="grid-column:${dow + 1};">
+          <span class="fb-mc-num">${d.getDate()}</span>
+          ${wx}
+        </div>`;
+      }
+
+      // Render bars (slot < MAX_SLOTS) and count overflow per dow
+      const overflowByDow = new Array(7).fill(0);
+      let bars = "";
+      for (const p of placed) {
+        if (p.slot >= MAX_SLOTS) {
+          for (let d = p.startDow; d < p.startDow + p.span; d++) overflowByDow[d]++;
+          continue;
+        }
+        bars += this._renderMonthBar(p, weekStart);
+      }
+      let mores = "";
+      for (let dow = 0; dow < 7; dow++) {
+        if (overflowByDow[dow] > 0) {
+          mores += `<span class="fb-mc-more" style="grid-column:${dow + 1};">+${overflowByDow[dow]} meer</span>`;
+        }
+      }
+
+      weeksHtml += `<div class="fb-month-week">${bgs}${heads}${bars}${mores}</div>`;
+    }
+
+    const error = this._error ? `<div class="fb-error">⚠ ${this._error}</div>` : "";
+    const loading = this._loading ? `<div class="fb-loading">…</div>` : "";
+
+    return `
+      ${error}
+      ${loading}
+      <div class="fb-month-dow">${dowHeader}</div>
+      <div class="fb-month-grid">${weeksHtml}</div>
+    `;
+  }
+
+  _renderMonthBar(seg, weekStart) {
+    const ev = seg.ev;
+    const bg = this._eventBackground(ev);
+    const reminderCls = ev.isReminder ? " fb-reminder" : "";
+    const dataAttr = ev.isReminder
+      ? `data-todo="${this._escape(ev.todoEntity || "")}" data-uid="${this._escape(ev.uid || "")}"`
+      : `data-sources="${encodeURIComponent(JSON.stringify(ev.sources))}"`;
+    const segDay = this._addDays(weekStart, seg.startDow);
+    const isAllDay = ev.allDay || this._spansFullDay(ev, segDay);
+    const prefix = ev.isReminder
+      ? "🔔 "
+      : isAllDay || seg.span > 1 || seg.isContPrev
+        ? ""
+        : `${this._formatTime(ev.startDate)} `;
+    const contClasses = [
+      seg.isContPrev ? "fb-mc-cont-prev" : "",
+      seg.isContNext ? "fb-mc-cont-next" : "",
+    ].filter(Boolean).join(" ");
+    const arrowL = seg.isContPrev ? "‹ " : "";
+    const arrowR = seg.isContNext ? " ›" : "";
+    return `<span class="fb-mc-bar${reminderCls} ${contClasses}" ${dataAttr}
+      style="grid-column:${seg.startDow + 1} / span ${seg.span}; grid-row:${seg.slot + 2}; background:${bg};"
+      title="${this._escape(ev.summary || "")}">${arrowL}${prefix}${this._escape(ev.summary || "(geen titel)")}${arrowR}</span>`;
   }
 
   // Does the event overlap day d (00:00 - 24:00)?

--- a/custom_components/familyboard/frontend/familyboard-calendar-card.js
+++ b/custom_components/familyboard/frontend/familyboard-calendar-card.js
@@ -1037,7 +1037,9 @@ class FamilyBoardCalendarCard extends HTMLElement {
       .fb-month-week {
         display: grid;
         grid-template-columns: repeat(7, minmax(0, 1fr));
-        grid-template-rows: 24px repeat(3, 18px) 14px;
+        grid-template-rows: 24px;
+        grid-auto-rows: 18px;
+        padding-bottom: 4px;
         position: relative;
         border-bottom: 1px solid var(--fb-border);
       }
@@ -1096,15 +1098,6 @@ class FamilyBoardCalendarCard extends HTMLElement {
       }
       .fb-mc-bar.fb-mc-cont-prev { border-top-left-radius: 0; border-bottom-left-radius: 0; margin-left: 0; }
       .fb-mc-bar.fb-mc-cont-next { border-top-right-radius: 0; border-bottom-right-radius: 0; margin-right: 0; }
-      .fb-mc-more {
-        grid-row: 5;
-        font-size: 0.65em;
-        color: var(--fb-muted);
-        padding: 0 4px;
-        text-align: left;
-        z-index: 1;
-        pointer-events: none;
-      }
 
       /* List layout */
       .fb-list { display: flex; flex-direction: column; }
@@ -1206,9 +1199,13 @@ class FamilyBoardCalendarCard extends HTMLElement {
       <ha-card>
         <style>${css}</style>
         <div class="fb-header">
-          <button class="fb-icon-btn" data-act="prev" title="Vorige">‹</button>
-          <button class="fb-btn" data-act="today">Vandaag</button>
-          <button class="fb-icon-btn" data-act="next" title="Volgende">›</button>
+          ${this._config.show_navigation ? `
+            <div class="fb-nav">
+              <button class="fb-icon-btn" data-act="prev" title="Vorige">‹</button>
+              <button class="fb-btn" data-act="today">Vandaag</button>
+              <button class="fb-icon-btn" data-act="next" title="Volgende">›</button>
+            </div>
+          ` : ""}
           <div class="fb-title"></div>
         </div>
         <div class="fb-body"><div class="fb-empty">Laden…</div></div>
@@ -1446,7 +1443,6 @@ class FamilyBoardCalendarCard extends HTMLElement {
       dowHeader += `<div class="fb-mc-dow">${this._escape(label)}</div>`;
     }
 
-    const MAX_SLOTS = 3; // visible event rows per week
     let weeksHtml = "";
     for (let w = 0; w < 6; w++) {
       const weekStart = days[w * 7];
@@ -1529,24 +1525,13 @@ class FamilyBoardCalendarCard extends HTMLElement {
         </div>`;
       }
 
-      // Render bars (slot < MAX_SLOTS) and count overflow per dow
-      const overflowByDow = new Array(7).fill(0);
+      // Render every placed segment; week row grows via grid-auto-rows
       let bars = "";
       for (const p of placed) {
-        if (p.slot >= MAX_SLOTS) {
-          for (let d = p.startDow; d < p.startDow + p.span; d++) overflowByDow[d]++;
-          continue;
-        }
         bars += this._renderMonthBar(p, weekStart);
       }
-      let mores = "";
-      for (let dow = 0; dow < 7; dow++) {
-        if (overflowByDow[dow] > 0) {
-          mores += `<span class="fb-mc-more" style="grid-column:${dow + 1};">+${overflowByDow[dow]} meer</span>`;
-        }
-      }
 
-      weeksHtml += `<div class="fb-month-week">${bgs}${heads}${bars}${mores}</div>`;
+      weeksHtml += `<div class="fb-month-week">${bgs}${heads}${bars}</div>`;
     }
 
     const error = this._error ? `<div class="fb-error">⚠ ${this._error}</div>` : "";

--- a/custom_components/familyboard/frontend/familyboard-chores-card.js
+++ b/custom_components/familyboard/frontend/familyboard-chores-card.js
@@ -131,9 +131,17 @@ class FamilyBoardChoresCard extends HTMLElement {
     } else if (view === "tomorrow") {
       endDate = new Date(today);
       endDate.setDate(endDate.getDate() + 1);
+    } else if (view === "today_tomorrow") {
+      endDate = new Date(today);
+      endDate.setDate(endDate.getDate() + 1);
     } else if (view === "week") {
       endDate = new Date(today);
       endDate.setDate(endDate.getDate() + 7);
+    } else if (view === "work_week") {
+      // Mon..Fri of current week
+      endDate = new Date(today);
+      const dow = (today.getDay() + 6) % 7; // Mon=0
+      endDate.setDate(today.getDate() - dow + 4);
     } else if (view === "two_weeks") {
       endDate = new Date(today);
       endDate.setDate(endDate.getDate() + 14);

--- a/custom_components/familyboard/frontend/familyboard-strategy.js
+++ b/custom_components/familyboard/frontend/familyboard-strategy.js
@@ -201,7 +201,9 @@ function _lijstCard(cfg, members) {
             const v = states['${cfg.view_entity}'].state;
             if (v === 'today') return 1;
             if (v === 'tomorrow') return 2;
+            if (v === 'today_tomorrow') return 2;
             if (v === 'week') return 7;
+            if (v === 'work_week') return 5;
             if (v === 'two_weeks') return 14;
             return 'month';
           })()`,
@@ -209,7 +211,9 @@ function _lijstCard(cfg, members) {
             const v = states['${cfg.view_entity}'].state;
             if (v === 'today') return 'today';
             if (v === 'tomorrow') return 'tomorrow';
+            if (v === 'today_tomorrow') return 'today';
             if (v === 'week') return 'monday';
+            if (v === 'work_week') return 'monday';
             if (v === 'month') return 'monday';
             return 'today';
           })()`,

--- a/custom_components/familyboard/frontend/familyboard-view-card.js
+++ b/custom_components/familyboard/frontend/familyboard-view-card.js
@@ -17,6 +17,13 @@
  *   color: amber                                 # optional, selected color
  *   show_reminders: true                         # optional, append a Herinneringen toggle chip
  *   reminders_switch: switch.familyboard_show_reminders  # optional, entity backing the chip
+ *   hidden_options:                              # optional, hide chips for these option keys
+ *     - tomorrow
+ *     - work_week
+ *   visible_options:                             # optional, whitelist (wins over hidden_options)
+ *     - today
+ *     - week
+ *     - month
  *   extra_chips: []                              # optional, raw mushroom-chip dicts appended
  */
 
@@ -26,7 +33,9 @@ const DEFAULT_REMINDERS_SWITCH = "switch.familyboard_show_reminders";
 const DEFAULT_ICONS = {
   today: "mdi:calendar-today",
   tomorrow: "mdi:calendar-arrow-right",
+  today_tomorrow: "mdi:calendar-multiple",
   week: "mdi:calendar-week",
+  work_week: "mdi:briefcase-clock",
   two_weeks: "mdi:calendar-range",
   month: "mdi:calendar-month",
   list: "mdi:view-list",
@@ -75,8 +84,13 @@ class FamilyBoardViewCard extends HTMLElement {
       reminders_switch: config.reminders_switch || DEFAULT_REMINDERS_SWITCH,
       reminders_label: config.reminders_label || "Herinneringen",
       extra_chips: Array.isArray(config.extra_chips) ? config.extra_chips : [],
+      hidden_options: Array.isArray(config.hidden_options) ? config.hidden_options : [],
+      visible_options: Array.isArray(config.visible_options) ? config.visible_options : null,
       ...config,
     };
+    // Make sure caller's config doesn't accidentally override the normalized arrays.
+    this._config.hidden_options = Array.isArray(config.hidden_options) ? config.hidden_options : [];
+    this._config.visible_options = Array.isArray(config.visible_options) ? config.visible_options : null;
   }
 
   set hass(hass) {
@@ -109,8 +123,15 @@ class FamilyBoardViewCard extends HTMLElement {
   }
 
   _buildChips(stateObj) {
-    const options = stateObj?.attributes?.options || [];
+    const allOptions = stateObj?.attributes?.options || [];
     const current = stateObj?.state;
+    let options;
+    if (this._config.visible_options && this._config.visible_options.length) {
+      // Whitelist + preserve user-specified order; only keep entries the entity actually has.
+      options = this._config.visible_options.filter((o) => allOptions.includes(o));
+    } else {
+      options = allOptions.filter((o) => !this._config.hidden_options.includes(o));
+    }
     const chips = options.map((opt) => ({
       type: "template",
       icon: this._config.icons[opt] || "mdi:circle-outline",
@@ -175,6 +196,8 @@ class FamilyBoardViewCard extends HTMLElement {
       s: stateObj.state,
       lang: this._hass?.locale?.language || "",
       x: this._config.extra_chips.length,
+      h: this._config.hidden_options,
+      v: this._config.visible_options,
       r: this._config.show_reminders
         ? this._hass.states[this._config.reminders_switch]?.state || ""
         : "",

--- a/custom_components/familyboard/frontend/familyboard-view-card.js
+++ b/custom_components/familyboard/frontend/familyboard-view-card.js
@@ -256,7 +256,7 @@ class FamilyBoardViewCard extends HTMLElement {
   }
 }
 
-const VIEW_EDITOR_SCHEMA = [
+const VIEW_EDITOR_BASE_SCHEMA = [
   { name: "entity", required: true, selector: { entity: { domain: "select" } } },
   { name: "color", selector: { text: {} } },
   { name: "show_reminders", selector: { boolean: {} } },
@@ -276,6 +276,30 @@ const VIEW_EDITOR_SCHEMA = [
     },
   },
 ];
+
+function buildViewEditorSchema(hass, config) {
+  const optionItems = [];
+  const entityId = config?.entity;
+  const stateObj = entityId && hass ? hass.states[entityId] : null;
+  const options = stateObj?.attributes?.options;
+  if (Array.isArray(options) && options.length) {
+    for (const opt of options) {
+      optionItems.push({ value: opt, label: opt });
+    }
+  }
+  const optionsSelector = optionItems.length
+    ? { select: { mode: "list", multiple: true, options: optionItems } }
+    : { object: {} };
+  // Only one of hidden_options / visible_options is shown to keep the editor
+  // unambiguous (visible_options wins at runtime). visible_options is only
+  // exposed when the user has it already set in YAML.
+  const hasVisible =
+    Array.isArray(config?.visible_options) && config.visible_options.length > 0;
+  const optionsField = hasVisible
+    ? { name: "visible_options", selector: optionsSelector }
+    : { name: "hidden_options", selector: optionsSelector };
+  return [...VIEW_EDITOR_BASE_SCHEMA, optionsField];
+}
 
 class FamilyBoardViewCardEditor extends HTMLElement {
   constructor() {
@@ -300,7 +324,6 @@ class FamilyBoardViewCardEditor extends HTMLElement {
     if (!this._form) {
       this._form = document.createElement("ha-form");
       this._form.computeLabel = (s) => s.label || s.name;
-      this._form.schema = VIEW_EDITOR_SCHEMA;
       this._form.addEventListener("value-changed", (ev) => {
         ev.stopPropagation();
         this.dispatchEvent(
@@ -314,6 +337,7 @@ class FamilyBoardViewCardEditor extends HTMLElement {
       this.shadowRoot.appendChild(this._form);
     }
     if (this._hass) this._form.hass = this._hass;
+    this._form.schema = buildViewEditorSchema(this._hass, this._config);
     this._form.data = this._config;
   }
 }

--- a/custom_components/familyboard/translations/en.json
+++ b/custom_components/familyboard/translations/en.json
@@ -140,7 +140,9 @@
         "state": {
           "today": "Today",
           "tomorrow": "Tomorrow",
+          "today_tomorrow": "Today + Tomorrow",
           "week": "Week",
+          "work_week": "Work week",
           "two_weeks": "2 Weeks",
           "month": "Month"
         }

--- a/custom_components/familyboard/translations/nl.json
+++ b/custom_components/familyboard/translations/nl.json
@@ -140,7 +140,9 @@
         "state": {
           "today": "Vandaag",
           "tomorrow": "Morgen",
+          "today_tomorrow": "Vandaag + Morgen",
           "week": "Week",
+          "work_week": "Werkweek",
           "two_weeks": "2 Weken",
           "month": "Maand"
         }

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -27,7 +27,15 @@ def test_view_and_layout_options_are_lists() -> None:
     assert isinstance(VIEW_OPTIONS, list) and VIEW_OPTIONS
     assert isinstance(LAYOUT_OPTIONS, list) and LAYOUT_OPTIONS
     # Stable, language-neutral keys; user-visible labels live in translations.
-    assert VIEW_OPTIONS == ["today", "tomorrow", "week", "two_weeks", "month"]
+    assert VIEW_OPTIONS == [
+        "today",
+        "tomorrow",
+        "today_tomorrow",
+        "week",
+        "work_week",
+        "two_weeks",
+        "month",
+    ]
     assert LAYOUT_OPTIONS == ["list", "agenda"]
 
 


### PR DESCRIPTION
# 🗓️ Month grid and friends 

Native maandweergave in `familyboard-calendar-card`, plus drie companion view‑opties die er gratis bijkwamen.

## Highlights

### Native month view
Vervangt de Phase‑3 placeholder. 6×7 grid, week‑rijen, weather badge per cel, today/other‑month/weekend styling, multi‑member gradient balken, en tap‑to‑more‑info via de bestaande pipeline.

### Multi‑day events as continuous bars
Google‑Calendar style. Een 5‑daagse vakantie is één doorlopende strook over 5 kolommen, niet 5 losse pillen. Segmenten die over week‑grenzen heen lopen krijgen `‹` / `›` markers en behouden hun kleur. Greedy slot‑assignment per week (langste spans eerst, all‑day boven timed); max 3 zichtbare slots, daarboven `+N meer` per dag.

### Week start follows your HA profile
`familyboard-calendar-card` leest `hass.locale.firstWeekday` voor week‑, two‑weeks‑ en maand‑uitlijning. Wisselen in **HA Profile → First day of the week** werkt direct, net als de 24h/AM‑PM toggle. Geen extra FamilyBoard‑setting.

### Two new view options
- **Vandaag + Morgen** (`today_tomorrow`) — beide dagen naast elkaar in één 2‑koloms time‑grid.
- **Werkweek** (`work_week`) — Mon–Fri van de huidige week. Snapt altijd naar maandag, ook in het weekend.

Doorgevoerd in calendar‑card, chores‑card filter window, list‑mode strategy en NL/EN translations.

### Configurable chip filtering
`familyboard-view-card` accepteert nu `hidden_options:` of `visible_options:` om chips per dashboard te verbergen of whitelisten — zonder de select‑entiteit zelf aan te passen.

```yaml
type: custom:familyboard-view-card
hidden_options: [tomorrow, work_week]
# of:
visible_options: [today, week, month]
```

## Upgrade notes

- ⚠️ **Bestaande dashboards blijven werken** — alle nieuwe view‑opties zijn additief, en de week/two‑weeks/month layout volgt nu het HA‑profiel ipv hard‑coded maandag. Als je profiel op Sunday staat zal je dat zien terugkomen in de week‑grids; zet 'm op Monday als je het oude gedrag wil.
- Geen schema‑ of options‑flow wijzigingen.
- Geen nieuwe HACS dependencies.

## Tested

- ✅ `ruff check` + `ruff format --check`
- ✅ test_const.py aangepast voor de nieuwe `VIEW_OPTIONS`
- ⚠️ Volledige pytest‑suite alleen via dev‑container / CI (lokaal Python 3.10 te oud)

### Smoke‑test op kiosk
- [ ] HA Profile → Sunday/Monday wisselen → week‑ en maand‑grid headers volgen
- [ ] Werkweek‑chip op zaterdag → toont ma–vr van die week
- [ ] `Vandaag + Morgen` chip → 2 koloms time‑grid + chores filter window van 2 dagen
- [ ] Maand: 5‑daagse all‑day event = één doorlopende balk; event over week‑grens → `‹` / `›` op de juiste kant
- [ ] Multi‑member event op `calendar.familyboard_trash` → gradient balk in maand
- [ ] View‑card met `hidden_options: [tomorrow]` → chip verdwijnt op het dashboard, blijft beschikbaar in more‑info



Closes #27
