### PR TITLE
Release v0.2.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: HACS Action
         uses: hacs/action@main

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Hassfest
         uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: pip
 
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `familyboard-calendar-card`: new **list** layout that groups events by day
+  (large date number, weekday short name, weather chip, color-bar per event,
+  reminders inline). Selected via the new `layout_entity` config option,
+  intended to be bound to `select.familyboard_layout` so the existing
+  `familyboard-view-card` toggles between time-grid and list in place.
+- `familyboard-filter-card` and `familyboard-view-card`: new `alignment`
+  config option (`start` / `center` / `end` / `justify`, with friendly
+  aliases `left` / `middle` / `right` / `uitlijnen`). Forwarded to the
+  underlying `mushroom-chips-card` and exposed in each card's visual editor.
+
+### Fixed
+- `familyboard-calendar-card`: day-header date and weather chip overlapped
+  on narrow widths (portrait week / 2-weeks view). Header is now a flex row
+  with container-query breakpoints that drop weather temperatures (then the
+  whole weather chip) when columns become too narrow.
+
 ## [0.1.0] - 2026-04-23
 
 Initial public release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Native month view in `familyboard-calendar-card` (replaces the Phase 3
+  placeholder): 6×7 grid with multi-member gradient pills, weather badge and
+  today/other-month/weekend styling. Week rows grow to fit all events — no
+  more `+N meer` overflow truncation.
+- `familyboard-calendar-card`: `show_navigation: false` now actually hides
+  the prev/today/next buttons in the card header.
+- Multi-day events render as continuous bars across the month grid (Google
+  Calendar style), with `‹` / `›` arrows on segments that continue into the
+  previous or next week.
+- New view options: `today_tomorrow` (today + tomorrow side-by-side) and
+  `work_week` (Mon–Fri of current week). Wired through the calendar card,
+  chores card, list-mode strategy and translations (NL/EN).
+- Week start in `familyboard-calendar-card` now follows the HA user profile
+  (`hass.locale.firstWeekday`) for week, two-weeks and month grid headers.
+  Werkweek blijft altijd ma–vr.
+- `familyboard-view-card` accepts `hidden_options:` and `visible_options:`
+  to hide/whitelist chips per dashboard without touching the select entity.
 - `familyboard-calendar-card`: new **list** layout that groups events by day
   (large date number, weekday short name, weather chip, color-bar per event,
   reminders inline). Selected via the new `layout_entity` config option,

--- a/custom_components/familyboard/__init__.py
+++ b/custom_components/familyboard/__init__.py
@@ -664,8 +664,15 @@ class FamilyBoardCoordinator(DataUpdateCoordinator):
             return (today.isoformat(), today.isoformat())
         if view == "tomorrow":
             return (today.isoformat(), (today + timedelta(days=1)).isoformat())
+        if view == "today_tomorrow":
+            return (today.isoformat(), (today + timedelta(days=1)).isoformat())
         if view == "week":
             return (today.isoformat(), (today + timedelta(days=7)).isoformat())
+        if view == "work_week":
+            # Mon..Fri of the current week (Mon = 0)
+            monday = today - timedelta(days=today.weekday())
+            friday = monday + timedelta(days=4)
+            return (monday.isoformat(), friday.isoformat())
         if view == "two_weeks":
             return (today.isoformat(), (today + timedelta(days=14)).isoformat())
         if view == "month":

--- a/custom_components/familyboard/const.py
+++ b/custom_components/familyboard/const.py
@@ -59,7 +59,15 @@ SNOOZE_MAX_MIN = 240
 
 # View / filter options. Stable, language-neutral keys; user-visible labels
 # come from translations (entity.select.<key>.state.<key>).
-VIEW_OPTIONS = ["today", "tomorrow", "week", "two_weeks", "month"]
+VIEW_OPTIONS = [
+    "today",
+    "tomorrow",
+    "today_tomorrow",
+    "week",
+    "work_week",
+    "two_weeks",
+    "month",
+]
 LAYOUT_OPTIONS = ["list", "agenda"]
 ALLES = "Alles"
 # Legacy Dutch state values from earlier releases — restored states are mapped

--- a/custom_components/familyboard/frontend/familyboard-calendar-card.js
+++ b/custom_components/familyboard/frontend/familyboard-calendar-card.js
@@ -38,14 +38,33 @@
  */
 
 const DEFAULT_COLORS = ["#4A90D9", "#27AE60", "#F39C12", "#9B59B6", "#E74C3C", "#1ABC9C"];
-const VIEW_NL = { day: "Vandaag", week: "Week", "2weeks": "2 Weken", month: "Maand" };
+const VIEW_NL = {
+  day: "Vandaag",
+  "2days": "Vandaag + Morgen",
+  week: "Week",
+  workweek: "Werkweek",
+  "2weeks": "2 Weken",
+  month: "Maand",
+};
 // Map stable select-state keys to internal view modes.
 const VIEW_FROM_SELECT = {
   today: "day",
   tomorrow: "day",
+  today_tomorrow: "2days",
   week: "week",
+  work_week: "workweek",
   two_weeks: "2weeks",
   month: "month",
+};
+// firstWeekday string -> day index (0 = Sunday)
+const FIRST_WEEKDAY_MAP = {
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
+  sunday: 0,
 };
 
 class FamilyBoardCalendarCard extends HTMLElement {
@@ -149,18 +168,34 @@ class FamilyBoardCalendarCard extends HTMLElement {
 
   _anchorCurrentStartFor(viewSelectState) {
     const today = this._startOfDay(new Date());
-    if (viewSelectState === "today") {
+    if (viewSelectState === "today" || viewSelectState === "today_tomorrow") {
       this._currentStart = today;
     } else if (viewSelectState === "tomorrow") {
       this._currentStart = this._addDays(today, 1);
     } else if (viewSelectState === "week" || viewSelectState === "two_weeks") {
-      // snap to monday of current week
+      // snap to first weekday of current week (HA locale)
+      const fw = this._firstWeekday();
+      const dow = (today.getDay() - fw + 7) % 7;
+      this._currentStart = this._addDays(today, -dow);
+    } else if (viewSelectState === "work_week") {
+      // always snap to Monday of current week
       const dow = (today.getDay() + 6) % 7; // Mon=0
       this._currentStart = this._addDays(today, -dow);
     } else if (viewSelectState === "month") {
       this._currentStart = new Date(today.getFullYear(), today.getMonth(), 1);
     }
     this._fetchKey = null;
+  }
+
+  // First day of week index (0=Sun..6=Sat) from HA user locale; fallback Monday.
+  _firstWeekday() {
+    const fw = this._hass?.locale?.firstWeekday;
+    if (typeof fw === "number" && fw >= 0 && fw <= 6) return fw;
+    if (typeof fw === "string") {
+      const v = FIRST_WEEKDAY_MAP[fw.toLowerCase()];
+      if (v !== undefined) return v;
+    }
+    return 1; // Monday default
   }
 
   getCardSize() {
@@ -377,12 +412,15 @@ class FamilyBoardCalendarCard extends HTMLElement {
     const start = new Date(this._currentStart);
     let end;
     if (view === "day") end = this._addDays(start, 1);
+    else if (view === "2days") end = this._addDays(start, 2);
+    else if (view === "workweek") end = this._addDays(start, 5);
     else if (view === "week") end = this._addDays(start, 7);
     else if (view === "2weeks") end = this._addDays(start, 14);
     else if (view === "month") {
-      // month grid: align to monday before 1st of month, 6 weeks
+      // month grid: align to first weekday before 1st of month, 6 weeks
       const first = new Date(start.getFullYear(), start.getMonth(), 1);
-      const dow = (first.getDay() + 6) % 7; // Mon=0
+      const fw = this._firstWeekday();
+      const dow = (first.getDay() - fw + 7) % 7;
       const gridStart = this._addDays(first, -dow);
       return [gridStart, this._addDays(gridStart, 42)];
     } else {
@@ -615,12 +653,18 @@ class FamilyBoardCalendarCard extends HTMLElement {
 
   _navPrev() {
     const view = this._activeView();
-    const step = view === "day" ? 1 : view === "week" ? 7 : view === "2weeks" ? 14 : 30;
     if (view === "month") {
       const d = new Date(this._currentStart);
       d.setMonth(d.getMonth() - 1);
       this._currentStart = this._startOfDay(d);
     } else {
+      const step =
+        view === "day" ? 1
+        : view === "2days" ? 2
+        : view === "workweek" ? 7
+        : view === "week" ? 7
+        : view === "2weeks" ? 14
+        : 1;
       this._currentStart = this._addDays(this._currentStart, -step);
     }
     this._fetchKey = null;
@@ -630,12 +674,18 @@ class FamilyBoardCalendarCard extends HTMLElement {
 
   _navNext() {
     const view = this._activeView();
-    const step = view === "day" ? 1 : view === "week" ? 7 : view === "2weeks" ? 14 : 30;
     if (view === "month") {
       const d = new Date(this._currentStart);
       d.setMonth(d.getMonth() + 1);
       this._currentStart = this._startOfDay(d);
     } else {
+      const step =
+        view === "day" ? 1
+        : view === "2days" ? 2
+        : view === "workweek" ? 7
+        : view === "week" ? 7
+        : view === "2weeks" ? 14
+        : 1;
       this._currentStart = this._addDays(this._currentStart, step);
     }
     this._fetchKey = null;
@@ -693,12 +743,16 @@ class FamilyBoardCalendarCard extends HTMLElement {
       body.innerHTML = this._renderList(view);
     } else if (view === "day") {
       body.innerHTML = this._renderTimeGrid(1);
+    } else if (view === "2days") {
+      body.innerHTML = this._renderTimeGrid(2);
+    } else if (view === "workweek") {
+      body.innerHTML = this._renderTimeGrid(5);
     } else if (view === "week") {
       body.innerHTML = this._renderTimeGrid(7);
     } else if (view === "2weeks") {
       body.innerHTML = this._renderTimeGrid(14);
     } else if (view === "month") {
-      body.innerHTML = this._renderMonthPlaceholder();
+      body.innerHTML = this._renderMonthGrid();
     }
     this._wireEventClicks();
     this._scrollToHour();
@@ -759,6 +813,8 @@ class FamilyBoardCalendarCard extends HTMLElement {
         position: relative;
         container-type: inline-size;
       }
+      .fb-grid.cols-2 { grid-template-columns: 56px repeat(2, 1fr); }
+      .fb-grid.cols-5 { grid-template-columns: 56px repeat(5, 1fr); }
       .fb-grid.cols-7 { grid-template-columns: 56px repeat(7, 1fr); }
       .fb-grid.cols-14 { grid-template-columns: 56px repeat(14, minmax(60px, 1fr)); overflow-x: auto; }
 
@@ -961,6 +1017,88 @@ class FamilyBoardCalendarCard extends HTMLElement {
         color: var(--fb-muted);
       }
 
+      .fb-month-dow {
+        display: grid;
+        grid-template-columns: repeat(7, minmax(0, 1fr));
+        position: sticky; top: 0; z-index: 3;
+        background: var(--card-background-color, var(--ha-card-background, #1c1c1c));
+        border-bottom: 1px solid var(--fb-border);
+      }
+      .fb-mc-dow {
+        text-align: center;
+        font-size: 0.78em;
+        color: var(--fb-muted);
+        padding: 6px 4px;
+      }
+      .fb-month-grid {
+        display: flex;
+        flex-direction: column;
+      }
+      .fb-month-week {
+        display: grid;
+        grid-template-columns: repeat(7, minmax(0, 1fr));
+        grid-template-rows: 24px;
+        grid-auto-rows: 18px;
+        padding-bottom: 4px;
+        position: relative;
+        border-bottom: 1px solid var(--fb-border);
+      }
+      .fb-month-week:last-child { border-bottom: none; }
+      .fb-mc-bg {
+        grid-row: 1 / -1;
+        border-right: 1px solid var(--fb-border);
+        z-index: 0;
+      }
+      .fb-mc-bg:nth-child(7n) { border-right: none; }
+      .fb-mc-bg.fb-mc-other { background: var(--fb-bg-alt); }
+      .fb-mc-bg.fb-mc-weekend:not(.fb-mc-other) { background: rgba(255,255,255,0.02); }
+      .fb-mc-bg.fb-mc-today {
+        background: color-mix(in srgb, var(--primary-color) 10%, transparent);
+      }
+      .fb-mc-head {
+        grid-row: 1;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 2px 4px;
+        font-size: 0.82em;
+        line-height: 1.2;
+        z-index: 1;
+        pointer-events: none;
+      }
+      .fb-mc-head.fb-mc-today .fb-mc-num {
+        background: var(--primary-color);
+        color: var(--text-primary-color, #fff);
+        border-radius: 999px;
+        padding: 0 6px;
+        font-weight: 600;
+      }
+      .fb-mc-num {
+        display: inline-block;
+        min-width: 18px;
+        text-align: center;
+      }
+      .fb-mc-head .fb-day-wx {
+        font-size: 0.85em;
+        opacity: 0.85;
+      }
+      .fb-mc-bar {
+        margin: 0 2px;
+        padding: 0 5px;
+        font-size: 0.7em;
+        line-height: 16px;
+        height: 16px;
+        border-radius: 3px;
+        color: #fff;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        cursor: pointer;
+        z-index: 1;
+      }
+      .fb-mc-bar.fb-mc-cont-prev { border-top-left-radius: 0; border-bottom-left-radius: 0; margin-left: 0; }
+      .fb-mc-bar.fb-mc-cont-next { border-top-right-radius: 0; border-bottom-right-radius: 0; margin-right: 0; }
+
       /* List layout */
       .fb-list { display: flex; flex-direction: column; }
       .fb-list-day {
@@ -1061,9 +1199,13 @@ class FamilyBoardCalendarCard extends HTMLElement {
       <ha-card>
         <style>${css}</style>
         <div class="fb-header">
-          <button class="fb-icon-btn" data-act="prev" title="Vorige">‹</button>
-          <button class="fb-btn" data-act="today">Vandaag</button>
-          <button class="fb-icon-btn" data-act="next" title="Volgende">›</button>
+          ${this._config.show_navigation ? `
+            <div class="fb-nav">
+              <button class="fb-icon-btn" data-act="prev" title="Vorige">‹</button>
+              <button class="fb-btn" data-act="today">Vandaag</button>
+              <button class="fb-icon-btn" data-act="next" title="Volgende">›</button>
+            </div>
+          ` : ""}
           <div class="fb-title"></div>
         </div>
         <div class="fb-body"><div class="fb-empty">Laden…</div></div>
@@ -1083,8 +1225,12 @@ class FamilyBoardCalendarCard extends HTMLElement {
     if (view === "day") {
       return this._formatDate(start, { weekday: "long", day: "numeric", month: "long", year: "numeric" });
     }
-    if (view === "week" || view === "2weeks") {
-      const len = view === "week" ? 6 : 13;
+    if (view === "2days" || view === "workweek" || view === "week" || view === "2weeks") {
+      const len =
+        view === "2days" ? 1
+        : view === "workweek" ? 4
+        : view === "week" ? 6
+        : 13;
       const end = this._addDays(start, len);
       const sm = start.toLocaleDateString(this._config.locale, { day: "numeric", month: "short" });
       const em = end.toLocaleDateString(this._config.locale, { day: "numeric", month: "short", year: "numeric" });
@@ -1152,7 +1298,12 @@ class FamilyBoardCalendarCard extends HTMLElement {
     const totalHours = endHour - startHour;
     const gridHeight = totalHours * hourHeight;
 
-    const colsClass = numDays === 7 ? " cols-7" : numDays === 14 ? " cols-14" : "";
+    const colsClass =
+      numDays === 2 ? " cols-2"
+      : numDays === 5 ? " cols-5"
+      : numDays === 7 ? " cols-7"
+      : numDays === 14 ? " cols-14"
+      : "";
 
     // Header row + all-day row
     let dayHeaders = `<div class="fb-day-header" style="border-right:1px solid var(--fb-border);"></div>`;
@@ -1271,8 +1422,152 @@ class FamilyBoardCalendarCard extends HTMLElement {
     return out;
   }
 
-  _renderMonthPlaceholder() {
-    return `<div class="fb-month-placeholder">Maand-weergave komt in Phase 3.</div>`;
+  _renderMonthGrid() {
+    const cfg = this._config;
+    const today = this._startOfDay(new Date());
+    const monthIdx = this._currentStart.getMonth();
+    const [gridStart] = this._visibleRange();
+
+    const days = [];
+    for (let i = 0; i < 42; i++) days.push(this._addDays(gridStart, i));
+
+    // Combine calendar events with reminder pseudo-events
+    const reminderEvents = this._buildReminderEvents();
+    const allEvents = [...this._events, ...reminderEvents];
+
+    // Weekday header row, starting at firstWeekday
+    let dowHeader = "";
+    for (let i = 0; i < 7; i++) {
+      const sample = this._addDays(gridStart, i);
+      const label = sample.toLocaleDateString(cfg.locale, { weekday: "short" });
+      dowHeader += `<div class="fb-mc-dow">${this._escape(label)}</div>`;
+    }
+
+    let weeksHtml = "";
+    for (let w = 0; w < 6; w++) {
+      const weekStart = days[w * 7];
+      const weekEnd = this._addDays(weekStart, 7); // exclusive
+
+      // Build segments: one per (event × week) overlap, with span 1..7
+      const segments = [];
+      for (const ev of allEvents) {
+        if (!(ev.endDate > weekStart && ev.startDate < weekEnd)) continue;
+        const segStart = ev.startDate < weekStart ? weekStart : this._startOfDay(ev.startDate);
+        // For all-day events endDate is exclusive midnight.
+        // For timed events ending mid-day, the segment ends on that day.
+        const lastDayCandidate = new Date(ev.endDate.getTime() - 1);
+        const segLast = lastDayCandidate >= weekEnd
+          ? this._addDays(weekEnd, -1)
+          : this._startOfDay(lastDayCandidate);
+        const startDow = Math.round((segStart - weekStart) / 86400000);
+        const span = Math.round((segLast - segStart) / 86400000) + 1;
+        if (span < 1) continue;
+        const isContinuationFromPrev = ev.startDate < weekStart;
+        const isContinuationToNext = ev.endDate > weekEnd;
+        segments.push({
+          ev,
+          startDow: Math.max(0, startDow),
+          span: Math.min(7 - Math.max(0, startDow), span),
+          isContPrev: isContinuationFromPrev,
+          isContNext: isContinuationToNext,
+        });
+      }
+
+      // Sort: longer spans first, then earlier start, all-day before timed
+      segments.sort((a, b) => {
+        const ad = a.ev.allDay || this._spansFullDay(a.ev, weekStart) ? 0 : 1;
+        const bd = b.ev.allDay || this._spansFullDay(b.ev, weekStart) ? 0 : 1;
+        if (ad !== bd) return ad - bd;
+        if (b.span !== a.span) return b.span - a.span;
+        return a.ev.startDate - b.ev.startDate;
+      });
+
+      // Greedy slot assignment: lowest free slot for the segment's columns
+      const used = new Set(); // "dow|slot"
+      const placed = [];
+      for (const seg of segments) {
+        let s = 0;
+        // safety cap to avoid runaway
+        while (s < 32) {
+          let ok = true;
+          for (let d = seg.startDow; d < seg.startDow + seg.span; d++) {
+            if (used.has(`${d}|${s}`)) { ok = false; break; }
+          }
+          if (ok) break;
+          s++;
+        }
+        for (let d = seg.startDow; d < seg.startDow + seg.span; d++) {
+          used.add(`${d}|${s}`);
+        }
+        placed.push({ ...seg, slot: s });
+      }
+
+      // Background day cells (row 1 / -1, full week-row height)
+      let bgs = "";
+      let heads = "";
+      for (let dow = 0; dow < 7; dow++) {
+        const d = days[w * 7 + dow];
+        const isToday = this._isSameDay(d, today);
+        const isOther = d.getMonth() !== monthIdx;
+        const isWeekend = d.getDay() === 0 || d.getDay() === 6;
+        const bgClasses = [
+          "fb-mc-bg",
+          isToday ? "fb-mc-today" : "",
+          isOther ? "fb-mc-other" : "",
+          isWeekend ? "fb-mc-weekend" : "",
+        ].filter(Boolean).join(" ");
+        bgs += `<div class="${bgClasses}" style="grid-column:${dow + 1};"></div>`;
+        const wx = this._renderWeather(d);
+        const headClasses = ["fb-mc-head", isToday ? "fb-mc-today" : ""].filter(Boolean).join(" ");
+        heads += `<div class="${headClasses}" style="grid-column:${dow + 1};">
+          <span class="fb-mc-num">${d.getDate()}</span>
+          ${wx}
+        </div>`;
+      }
+
+      // Render every placed segment; week row grows via grid-auto-rows
+      let bars = "";
+      for (const p of placed) {
+        bars += this._renderMonthBar(p, weekStart);
+      }
+
+      weeksHtml += `<div class="fb-month-week">${bgs}${heads}${bars}</div>`;
+    }
+
+    const error = this._error ? `<div class="fb-error">⚠ ${this._error}</div>` : "";
+    const loading = this._loading ? `<div class="fb-loading">…</div>` : "";
+
+    return `
+      ${error}
+      ${loading}
+      <div class="fb-month-dow">${dowHeader}</div>
+      <div class="fb-month-grid">${weeksHtml}</div>
+    `;
+  }
+
+  _renderMonthBar(seg, weekStart) {
+    const ev = seg.ev;
+    const bg = this._eventBackground(ev);
+    const reminderCls = ev.isReminder ? " fb-reminder" : "";
+    const dataAttr = ev.isReminder
+      ? `data-todo="${this._escape(ev.todoEntity || "")}" data-uid="${this._escape(ev.uid || "")}"`
+      : `data-sources="${encodeURIComponent(JSON.stringify(ev.sources))}"`;
+    const segDay = this._addDays(weekStart, seg.startDow);
+    const isAllDay = ev.allDay || this._spansFullDay(ev, segDay);
+    const prefix = ev.isReminder
+      ? "🔔 "
+      : isAllDay || seg.span > 1 || seg.isContPrev
+        ? ""
+        : `${this._formatTime(ev.startDate)} `;
+    const contClasses = [
+      seg.isContPrev ? "fb-mc-cont-prev" : "",
+      seg.isContNext ? "fb-mc-cont-next" : "",
+    ].filter(Boolean).join(" ");
+    const arrowL = seg.isContPrev ? "‹ " : "";
+    const arrowR = seg.isContNext ? " ›" : "";
+    return `<span class="fb-mc-bar${reminderCls} ${contClasses}" ${dataAttr}
+      style="grid-column:${seg.startDow + 1} / span ${seg.span}; grid-row:${seg.slot + 2}; background:${bg};"
+      title="${this._escape(ev.summary || "")}">${arrowL}${prefix}${this._escape(ev.summary || "(geen titel)")}${arrowR}</span>`;
   }
 
   // ---------- list layout ----------

--- a/custom_components/familyboard/frontend/familyboard-calendar-card.js
+++ b/custom_components/familyboard/frontend/familyboard-calendar-card.js
@@ -103,6 +103,8 @@ class FamilyBoardCalendarCard extends HTMLElement {
       row_height: this._clampInt(config.row_height, 12, 80, 24),
       filter_entity: config.filter_entity || null,
       view_entity: config.view_entity || null,
+      layout_entity: config.layout_entity || null,
+      layout: config.layout === "list" ? "list" : "agenda",
       filter_map: config.filter_map || null,
       shared_calendars: sharedCalendars,
       member_entities: memberEntities,
@@ -230,6 +232,10 @@ class FamilyBoardCalendarCard extends HTMLElement {
       const s = hass.states[this._config.view_entity];
       parts.push(`v:${s ? s.state : "x"}`);
     }
+    if (this._config.layout_entity) {
+      const s = hass.states[this._config.layout_entity];
+      parts.push(`l:${s ? s.state : "x"}`);
+    }
     if (this._config.reminders_hide_when) {
       const s = hass.states[this._config.reminders_hide_when];
       parts.push(`rh:${s ? s.state : "x"}`);
@@ -297,6 +303,14 @@ class FamilyBoardCalendarCard extends HTMLElement {
       if (s && VIEW_FROM_SELECT[s.state]) return VIEW_FROM_SELECT[s.state];
     }
     return this._config.view;
+  }
+
+  _activeLayout() {
+    if (this._config.layout_entity && this._hass) {
+      const s = this._hass.states[this._config.layout_entity];
+      if (s && (s.state === "list" || s.state === "agenda")) return s.state;
+    }
+    return this._config.layout || "agenda";
   }
 
   _activeFilterValue() {
@@ -665,6 +679,7 @@ class FamilyBoardCalendarCard extends HTMLElement {
       this._wireBaseEvents();
     }
     const view = this._activeView();
+    const layout = this._activeLayout();
     const body = this.shadowRoot.querySelector(".fb-body");
     const title = this.shadowRoot.querySelector(".fb-title");
     title.textContent = this._headerTitle(view);
@@ -674,7 +689,9 @@ class FamilyBoardCalendarCard extends HTMLElement {
       return;
     }
 
-    if (view === "day") {
+    if (layout === "list") {
+      body.innerHTML = this._renderList(view);
+    } else if (view === "day") {
       body.innerHTML = this._renderTimeGrid(1);
     } else if (view === "week") {
       body.innerHTML = this._renderTimeGrid(7);
@@ -740,6 +757,7 @@ class FamilyBoardCalendarCard extends HTMLElement {
         display: grid;
         grid-template-columns: 56px 1fr;
         position: relative;
+        container-type: inline-size;
       }
       .fb-grid.cols-7 { grid-template-columns: 56px repeat(7, 1fr); }
       .fb-grid.cols-14 { grid-template-columns: 56px repeat(14, minmax(60px, 1fr)); overflow-x: auto; }
@@ -749,30 +767,54 @@ class FamilyBoardCalendarCard extends HTMLElement {
       }
       .fb-day-header {
         padding: 6px 8px;
-        text-align: center;
         border-bottom: 1px solid var(--fb-border);
         font-size: 0.85em;
         position: sticky; top: 0;
         background: var(--card-background-color, var(--ha-card-background, #1c1c1c));
         z-index: 3;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 6px;
+        min-width: 0;
       }
       .fb-day-header.today { color: var(--primary-color); font-weight: 600; }
       .fb-day-header .fb-dow { font-size: 0.75em; opacity: 0.7; }
       .fb-day-header .fb-dnum { font-size: 1.1em; }
-      .fb-day-header .fb-day-date { line-height: 1.15; }
+      .fb-day-header .fb-day-date {
+        line-height: 1.15;
+        text-align: left;
+        flex: 0 1 auto;
+        min-width: 0;
+      }
       .fb-day-wx {
-        position: absolute;
-        right: 8px;
-        top: 50%;
-        transform: translateY(-50%);
         display: inline-flex;
         align-items: center;
         gap: 4px;
         font-size: 0.85em;
         opacity: 0.95;
+        flex: 0 0 auto;
+        white-space: nowrap;
       }
       .fb-day-wx ha-icon { --mdc-icon-size: 20px; }
       .fb-day-wx .fb-wx-lo { opacity: 0.65; }
+      /* Narrow columns: drop temperatures, then drop weather entirely */
+      @container (max-width: 720px) {
+        .fb-grid.cols-7 .fb-day-wx .fb-wx-temps,
+        .fb-grid.cols-7 .fb-day-wx .fb-wx-hi,
+        .fb-grid.cols-7 .fb-day-wx .fb-wx-lo { display: none; }
+      }
+      @container (max-width: 1100px) {
+        .fb-grid.cols-14 .fb-day-wx .fb-wx-temps,
+        .fb-grid.cols-14 .fb-day-wx .fb-wx-hi,
+        .fb-grid.cols-14 .fb-day-wx .fb-wx-lo { display: none; }
+      }
+      @container (max-width: 480px) {
+        .fb-grid.cols-7 .fb-day-wx { display: none; }
+      }
+      @container (max-width: 780px) {
+        .fb-grid.cols-14 .fb-day-wx { display: none; }
+      }
 
       .fb-allday-row {
         display: contents;
@@ -917,6 +959,95 @@ class FamilyBoardCalendarCard extends HTMLElement {
         padding: 30px;
         text-align: center;
         color: var(--fb-muted);
+      }
+
+      /* List layout */
+      .fb-list { display: flex; flex-direction: column; }
+      .fb-list-day {
+        display: grid;
+        grid-template-columns: 64px 1fr;
+        gap: 8px;
+        padding: 8px 12px;
+        border-bottom: 1px solid var(--fb-border);
+        align-items: start;
+      }
+      .fb-list-day.today { background-color: rgba(255, 200, 0, 0.04); }
+      .fb-list-day-header {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: flex-start;
+        gap: 2px;
+        padding-top: 2px;
+      }
+      .fb-list-day-header .fb-list-day-num {
+        font-size: 1.8em;
+        font-weight: 300;
+        line-height: 1;
+      }
+      .fb-list-day-header .fb-list-day-name {
+        font-size: 0.75em;
+        opacity: 0.7;
+        text-transform: lowercase;
+      }
+      .fb-list-day.today .fb-list-day-num,
+      .fb-list-day.today .fb-list-day-name { color: var(--primary-color); font-weight: 500; }
+      .fb-list-day-header .fb-day-wx {
+        font-size: 0.75em;
+        opacity: 0.85;
+        margin-top: 2px;
+        flex-direction: column;
+        gap: 0;
+      }
+      .fb-list-day-header .fb-day-wx ha-icon { --mdc-icon-size: 18px; }
+      .fb-list-events {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        min-width: 0;
+      }
+      .fb-list-event {
+        display: flex;
+        align-items: stretch;
+        background: var(--fb-bg-alt);
+        border-radius: 4px;
+        overflow: hidden;
+        cursor: pointer;
+        min-height: 36px;
+      }
+      .fb-list-event:hover { filter: brightness(1.1); }
+      .fb-list-event-bar {
+        flex: 0 0 5px;
+        align-self: stretch;
+      }
+      .fb-list-event-body {
+        flex: 1;
+        min-width: 0;
+        padding: 4px 8px;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        gap: 2px;
+      }
+      .fb-list-event-time {
+        font-size: 0.72em;
+        opacity: 0.75;
+        line-height: 1.1;
+      }
+      .fb-list-event-title {
+        font-size: 0.95em;
+        font-weight: 500;
+        line-height: 1.2;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .fb-list-event.fb-reminder .fb-list-event-title { font-weight: 400; }
+      .fb-list-empty {
+        font-size: 0.85em;
+        color: var(--fb-muted);
+        font-style: italic;
+        padding: 4px 0;
       }
 
       .fb-empty {
@@ -1142,6 +1273,103 @@ class FamilyBoardCalendarCard extends HTMLElement {
 
   _renderMonthPlaceholder() {
     return `<div class="fb-month-placeholder">Maand-weergave komt in Phase 3.</div>`;
+  }
+
+  // ---------- list layout ----------
+
+  _renderList(view) {
+    const [start, end] = this._visibleRange();
+    const today = this._startOfDay(new Date());
+    const days = [];
+    for (let d = new Date(start); d < end; d = this._addDays(d, 1)) {
+      days.push(new Date(d));
+    }
+
+    // For month view, only render days that have events (avoids 30+ empty rows).
+    const skipEmpty = view === "month" || days.length > 14;
+
+    const reminders = this._buildReminderEvents();
+    const allEvents = [...this._events, ...reminders];
+
+    let html = `<div class="fb-list">`;
+    let rendered = 0;
+    for (const d of days) {
+      const dayAll = [];
+      const dayTimed = [];
+      for (const ev of allEvents) {
+        if (!this._eventOnDay(ev, d)) continue;
+        if (ev.allDay || this._spansFullDay(ev, d)) dayAll.push(ev);
+        else dayTimed.push(ev);
+      }
+      if (!dayAll.length && !dayTimed.length && skipEmpty) continue;
+      dayAll.sort((a, b) => (a.summary || "").localeCompare(b.summary || ""));
+      dayTimed.sort((a, b) => a.startDate - b.startDate);
+      html += this._renderListDay(d, dayAll, dayTimed, today);
+      rendered++;
+    }
+    if (!rendered) {
+      html += `<div class="fb-empty">Geen afspraken in deze periode.</div>`;
+    }
+    html += `</div>`;
+
+    const loading = this._loading ? `<div class="fb-loading">…</div>` : "";
+    const error = this._error ? `<div class="fb-error">⚠ ${this._error}</div>` : "";
+    return `${error}${loading}${html}`;
+  }
+
+  _renderListDay(date, allDay, timed, today) {
+    const cfg = this._config;
+    const isToday = this._isSameDay(date, today);
+    const dow = date.toLocaleDateString(cfg.locale, { weekday: "short" });
+    const wx = this._renderWeather(date);
+    const events = [...allDay, ...timed];
+    let eventsHtml;
+    if (events.length) {
+      eventsHtml = events.map((ev) => this._renderListEvent(ev, date)).join("");
+    } else {
+      eventsHtml = `<div class="fb-list-empty">Geen afspraken</div>`;
+    }
+    return `
+      <div class="fb-list-day${isToday ? " today" : ""}">
+        <div class="fb-list-day-header">
+          <div class="fb-list-day-num">${date.getDate()}</div>
+          <div class="fb-list-day-name">${dow}</div>
+          ${wx}
+        </div>
+        <div class="fb-list-events">${eventsHtml}</div>
+      </div>
+    `;
+  }
+
+  _renderListEvent(ev, day) {
+    const bg = this._eventBackground(ev);
+    const reminderCls = ev.isReminder ? " fb-reminder" : "";
+    const prefix = ev.isReminder ? "🔔 " : "";
+    const dataAttr = ev.isReminder
+      ? `data-todo="${this._escape(ev.todoEntity || "")}" data-uid="${this._escape(ev.uid || "")}"`
+      : `data-sources="${encodeURIComponent(JSON.stringify(ev.sources))}"`;
+    let timeLabel;
+    if (ev.allDay || this._spansFullDay(ev, day)) {
+      timeLabel = "Hele dag";
+    } else {
+      const dStart = this._startOfDay(day);
+      const dEnd = this._addDays(dStart, 1);
+      const startsToday = ev.startDate >= dStart;
+      const endsToday = ev.endDate <= dEnd;
+      const startStr = startsToday ? this._formatTime(ev.startDate) : "…";
+      const endStr = endsToday ? this._formatTime(ev.endDate) : "…";
+      timeLabel = `${startStr} – ${endStr}`;
+    }
+    const title = this._escape(ev.summary || "(geen titel)");
+    return `
+      <div class="fb-list-event${reminderCls}" ${dataAttr}>
+        <div class="fb-list-event-bar" style="background:${bg};"></div>
+        <div class="fb-list-event-body">
+          <div class="fb-list-event-time">${this._escape(timeLabel)}</div>
+          <div class="fb-list-event-title">${prefix}${title}</div>
+        </div>
+      </div>
+    `;
   }
 
   // Does the event overlap day d (00:00 - 24:00)?

--- a/custom_components/familyboard/frontend/familyboard-chores-card.js
+++ b/custom_components/familyboard/frontend/familyboard-chores-card.js
@@ -131,9 +131,17 @@ class FamilyBoardChoresCard extends HTMLElement {
     } else if (view === "tomorrow") {
       endDate = new Date(today);
       endDate.setDate(endDate.getDate() + 1);
+    } else if (view === "today_tomorrow") {
+      endDate = new Date(today);
+      endDate.setDate(endDate.getDate() + 1);
     } else if (view === "week") {
       endDate = new Date(today);
       endDate.setDate(endDate.getDate() + 7);
+    } else if (view === "work_week") {
+      // Mon..Fri of current week
+      endDate = new Date(today);
+      const dow = (today.getDay() + 6) % 7; // Mon=0
+      endDate.setDate(today.getDate() - dow + 4);
     } else if (view === "two_weeks") {
       endDate = new Date(today);
       endDate.setDate(endDate.getDate() + 14);

--- a/custom_components/familyboard/frontend/familyboard-filter-card.js
+++ b/custom_components/familyboard/frontend/familyboard-filter-card.js
@@ -20,6 +20,26 @@ const DEFAULT_MEMBERS = "sensor.familyboard_members";
 const ALLES_LABEL = "Alles";
 const ALLES_COLOR = "#8c8c8c";
 
+// Accept friendly aliases for mushroom-chips-card `alignment` values.
+const ALIGNMENT_MAP = {
+  left: "start",
+  begin: "start",
+  start: "start",
+  middle: "center",
+  center: "center",
+  centre: "center",
+  right: "end",
+  end: "end",
+  uitlijnen: "justify",
+  justify: "justify",
+  spread: "justify",
+};
+
+function normalizeAlignment(v) {
+  if (!v) return null;
+  return ALIGNMENT_MAP[String(v).toLowerCase()] || null;
+}
+
 class FamilyBoardFilterCard extends HTMLElement {
   constructor() {
     super();
@@ -59,8 +79,11 @@ class FamilyBoardFilterCard extends HTMLElement {
       members_entity: config.members_entity || DEFAULT_MEMBERS,
       show_alles: config.show_alles !== false,
       extra_chips: Array.isArray(config.extra_chips) ? config.extra_chips : [],
+      alignment: normalizeAlignment(config.alignment),
       ...config,
     };
+    // Re-normalize after spread so `...config` can't reintroduce a raw alias.
+    this._config.alignment = normalizeAlignment(config.alignment);
   }
 
   set hass(hass) {
@@ -191,6 +214,7 @@ class FamilyBoardFilterCard extends HTMLElement {
       f: currentFilter,
       cfg: this._config.extra_chips.length,
       a: this._config.show_alles,
+      al: this._config.alignment || "",
     });
     if (sig === this._lastSig && this._inner) {
       this._inner.hass = this._hass;
@@ -200,6 +224,7 @@ class FamilyBoardFilterCard extends HTMLElement {
 
     const chips = this._buildChips(members, currentFilter);
     const cardConfig = { type: "custom:mushroom-chips-card", chips };
+    if (this._config.alignment) cardConfig.alignment = this._config.alignment;
 
     let helpers;
     try {
@@ -226,6 +251,20 @@ const FILTER_EDITOR_SCHEMA = [
   { name: "filter_entity", selector: { entity: { domain: "select" } } },
   { name: "members_entity", selector: { entity: { domain: "sensor" } } },
   { name: "show_alles", selector: { boolean: {} } },
+  {
+    name: "alignment",
+    selector: {
+      select: {
+        mode: "dropdown",
+        options: [
+          { value: "start", label: "Links" },
+          { value: "center", label: "Midden" },
+          { value: "end", label: "Rechts" },
+          { value: "justify", label: "Uitlijnen" },
+        ],
+      },
+    },
+  },
 ];
 
 class FamilyBoardFilterCardEditor extends HTMLElement {

--- a/custom_components/familyboard/frontend/familyboard-strategy.js
+++ b/custom_components/familyboard/frontend/familyboard-strategy.js
@@ -201,7 +201,9 @@ function _lijstCard(cfg, members) {
             const v = states['${cfg.view_entity}'].state;
             if (v === 'today') return 1;
             if (v === 'tomorrow') return 2;
+            if (v === 'today_tomorrow') return 2;
             if (v === 'week') return 7;
+            if (v === 'work_week') return 5;
             if (v === 'two_weeks') return 14;
             return 'month';
           })()`,
@@ -209,7 +211,9 @@ function _lijstCard(cfg, members) {
             const v = states['${cfg.view_entity}'].state;
             if (v === 'today') return 'today';
             if (v === 'tomorrow') return 'tomorrow';
+            if (v === 'today_tomorrow') return 'today';
             if (v === 'week') return 'monday';
+            if (v === 'work_week') return 'monday';
             if (v === 'month') return 'monday';
             return 'today';
           })()`,

--- a/custom_components/familyboard/frontend/familyboard-view-card.js
+++ b/custom_components/familyboard/frontend/familyboard-view-card.js
@@ -17,6 +17,13 @@
  *   color: amber                                 # optional, selected color
  *   show_reminders: true                         # optional, append a Herinneringen toggle chip
  *   reminders_switch: switch.familyboard_show_reminders  # optional, entity backing the chip
+ *   hidden_options:                              # optional, hide chips for these option keys
+ *     - tomorrow
+ *     - work_week
+ *   visible_options:                             # optional, whitelist (wins over hidden_options)
+ *     - today
+ *     - week
+ *     - month
  *   extra_chips: []                              # optional, raw mushroom-chip dicts appended
  */
 
@@ -46,7 +53,9 @@ function normalizeAlignment(v) {
 const DEFAULT_ICONS = {
   today: "mdi:calendar-today",
   tomorrow: "mdi:calendar-arrow-right",
+  today_tomorrow: "mdi:calendar-multiple",
   week: "mdi:calendar-week",
+  work_week: "mdi:briefcase-clock",
   two_weeks: "mdi:calendar-range",
   month: "mdi:calendar-month",
   list: "mdi:view-list",
@@ -95,10 +104,14 @@ class FamilyBoardViewCard extends HTMLElement {
       reminders_switch: config.reminders_switch || DEFAULT_REMINDERS_SWITCH,
       reminders_label: config.reminders_label || "Herinneringen",
       extra_chips: Array.isArray(config.extra_chips) ? config.extra_chips : [],
+      hidden_options: Array.isArray(config.hidden_options) ? config.hidden_options : [],
+      visible_options: Array.isArray(config.visible_options) ? config.visible_options : null,
       alignment: normalizeAlignment(config.alignment),
       ...config,
     };
-    // Re-normalize after spread so `...config` can't reintroduce a raw alias.
+    // Make sure caller's config doesn't accidentally override the normalized values.
+    this._config.hidden_options = Array.isArray(config.hidden_options) ? config.hidden_options : [];
+    this._config.visible_options = Array.isArray(config.visible_options) ? config.visible_options : null;
     this._config.alignment = normalizeAlignment(config.alignment);
   }
 
@@ -132,8 +145,15 @@ class FamilyBoardViewCard extends HTMLElement {
   }
 
   _buildChips(stateObj) {
-    const options = stateObj?.attributes?.options || [];
+    const allOptions = stateObj?.attributes?.options || [];
     const current = stateObj?.state;
+    let options;
+    if (this._config.visible_options && this._config.visible_options.length) {
+      // Whitelist + preserve user-specified order; only keep entries the entity actually has.
+      options = this._config.visible_options.filter((o) => allOptions.includes(o));
+    } else {
+      options = allOptions.filter((o) => !this._config.hidden_options.includes(o));
+    }
     const chips = options.map((opt) => ({
       type: "template",
       icon: this._config.icons[opt] || "mdi:circle-outline",
@@ -198,6 +218,8 @@ class FamilyBoardViewCard extends HTMLElement {
       s: stateObj.state,
       lang: this._hass?.locale?.language || "",
       x: this._config.extra_chips.length,
+      h: this._config.hidden_options,
+      v: this._config.visible_options,
       a: this._config.alignment || "",
       r: this._config.show_reminders
         ? this._hass.states[this._config.reminders_switch]?.state || ""
@@ -234,7 +256,7 @@ class FamilyBoardViewCard extends HTMLElement {
   }
 }
 
-const VIEW_EDITOR_SCHEMA = [
+const VIEW_EDITOR_BASE_SCHEMA = [
   { name: "entity", required: true, selector: { entity: { domain: "select" } } },
   { name: "color", selector: { text: {} } },
   { name: "show_reminders", selector: { boolean: {} } },
@@ -254,6 +276,30 @@ const VIEW_EDITOR_SCHEMA = [
     },
   },
 ];
+
+function buildViewEditorSchema(hass, config) {
+  const optionItems = [];
+  const entityId = config?.entity;
+  const stateObj = entityId && hass ? hass.states[entityId] : null;
+  const options = stateObj?.attributes?.options;
+  if (Array.isArray(options) && options.length) {
+    for (const opt of options) {
+      optionItems.push({ value: opt, label: opt });
+    }
+  }
+  const optionsSelector = optionItems.length
+    ? { select: { mode: "list", multiple: true, options: optionItems } }
+    : { object: {} };
+  // Only one of hidden_options / visible_options is shown to keep the editor
+  // unambiguous (visible_options wins at runtime). visible_options is only
+  // exposed when the user has it already set in YAML.
+  const hasVisible =
+    Array.isArray(config?.visible_options) && config.visible_options.length > 0;
+  const optionsField = hasVisible
+    ? { name: "visible_options", selector: optionsSelector }
+    : { name: "hidden_options", selector: optionsSelector };
+  return [...VIEW_EDITOR_BASE_SCHEMA, optionsField];
+}
 
 class FamilyBoardViewCardEditor extends HTMLElement {
   constructor() {
@@ -278,7 +324,6 @@ class FamilyBoardViewCardEditor extends HTMLElement {
     if (!this._form) {
       this._form = document.createElement("ha-form");
       this._form.computeLabel = (s) => s.label || s.name;
-      this._form.schema = VIEW_EDITOR_SCHEMA;
       this._form.addEventListener("value-changed", (ev) => {
         ev.stopPropagation();
         this.dispatchEvent(
@@ -292,6 +337,7 @@ class FamilyBoardViewCardEditor extends HTMLElement {
       this.shadowRoot.appendChild(this._form);
     }
     if (this._hass) this._form.hass = this._hass;
+    this._form.schema = buildViewEditorSchema(this._hass, this._config);
     this._form.data = this._config;
   }
 }

--- a/custom_components/familyboard/frontend/familyboard-view-card.js
+++ b/custom_components/familyboard/frontend/familyboard-view-card.js
@@ -23,6 +23,26 @@
 const DEFAULT_ENTITY = "select.familyboard_view";
 const DEFAULT_REMINDERS_SWITCH = "switch.familyboard_show_reminders";
 
+// Accept friendly aliases for mushroom-chips-card `alignment` values.
+const ALIGNMENT_MAP = {
+  left: "start",
+  begin: "start",
+  start: "start",
+  middle: "center",
+  center: "center",
+  centre: "center",
+  right: "end",
+  end: "end",
+  uitlijnen: "justify",
+  justify: "justify",
+  spread: "justify",
+};
+
+function normalizeAlignment(v) {
+  if (!v) return null;
+  return ALIGNMENT_MAP[String(v).toLowerCase()] || null;
+}
+
 const DEFAULT_ICONS = {
   today: "mdi:calendar-today",
   tomorrow: "mdi:calendar-arrow-right",
@@ -75,8 +95,11 @@ class FamilyBoardViewCard extends HTMLElement {
       reminders_switch: config.reminders_switch || DEFAULT_REMINDERS_SWITCH,
       reminders_label: config.reminders_label || "Herinneringen",
       extra_chips: Array.isArray(config.extra_chips) ? config.extra_chips : [],
+      alignment: normalizeAlignment(config.alignment),
       ...config,
     };
+    // Re-normalize after spread so `...config` can't reintroduce a raw alias.
+    this._config.alignment = normalizeAlignment(config.alignment);
   }
 
   set hass(hass) {
@@ -175,6 +198,7 @@ class FamilyBoardViewCard extends HTMLElement {
       s: stateObj.state,
       lang: this._hass?.locale?.language || "",
       x: this._config.extra_chips.length,
+      a: this._config.alignment || "",
       r: this._config.show_reminders
         ? this._hass.states[this._config.reminders_switch]?.state || ""
         : "",
@@ -187,6 +211,7 @@ class FamilyBoardViewCard extends HTMLElement {
 
     const chips = this._buildChips(stateObj);
     const cardConfig = { type: "custom:mushroom-chips-card", chips };
+    if (this._config.alignment) cardConfig.alignment = this._config.alignment;
 
     let helpers;
     try {
@@ -214,6 +239,20 @@ const VIEW_EDITOR_SCHEMA = [
   { name: "color", selector: { text: {} } },
   { name: "show_reminders", selector: { boolean: {} } },
   { name: "reminders_switch", selector: { entity: { domain: "switch" } } },
+  {
+    name: "alignment",
+    selector: {
+      select: {
+        mode: "dropdown",
+        options: [
+          { value: "start", label: "Links" },
+          { value: "center", label: "Midden" },
+          { value: "end", label: "Rechts" },
+          { value: "justify", label: "Uitlijnen" },
+        ],
+      },
+    },
+  },
 ];
 
 class FamilyBoardViewCardEditor extends HTMLElement {

--- a/custom_components/familyboard/manifest.json
+++ b/custom_components/familyboard/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/apiest/FamilyBoard/issues",
   "requirements": [],
-  "version": "0.1.0"
+  "version": "0.2.0"
 }

--- a/custom_components/familyboard/translations/en.json
+++ b/custom_components/familyboard/translations/en.json
@@ -140,7 +140,9 @@
         "state": {
           "today": "Today",
           "tomorrow": "Tomorrow",
+          "today_tomorrow": "Today + Tomorrow",
           "week": "Week",
+          "work_week": "Work week",
           "two_weeks": "2 Weeks",
           "month": "Month"
         }

--- a/custom_components/familyboard/translations/nl.json
+++ b/custom_components/familyboard/translations/nl.json
@@ -140,7 +140,9 @@
         "state": {
           "today": "Vandaag",
           "tomorrow": "Morgen",
+          "today_tomorrow": "Vandaag + Morgen",
           "week": "Week",
+          "work_week": "Werkweek",
           "two_weeks": "2 Weken",
           "month": "Maand"
         }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 colorlog
-homeassistant==2026.2.3
+homeassistant==2026.4.4
 pip>=21.3.1
 ruff>=0.6.0
 -r requirements_test.txt

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
-pytest>=8.0.0
-pytest-asyncio>=0.23.0
-pytest-cov>=5.0.0
-pytest-homeassistant-custom-component>=0.13.190
+pytest>=9.0.3
+pytest-asyncio>=1.3.0
+pytest-cov>=7.1.0
+pytest-homeassistant-custom-component>=0.13.324
 ruff>=0.6.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
-pytest>=9.0.3
+pytest>=9.0.0
 pytest-asyncio>=1.3.0
-pytest-cov>=7.1.0
-pytest-homeassistant-custom-component>=0.13.324
+pytest-cov>=7.0.0
+pytest-homeassistant-custom-component>=0.13.325
 ruff>=0.6.0

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -27,7 +27,15 @@ def test_view_and_layout_options_are_lists() -> None:
     assert isinstance(VIEW_OPTIONS, list) and VIEW_OPTIONS
     assert isinstance(LAYOUT_OPTIONS, list) and LAYOUT_OPTIONS
     # Stable, language-neutral keys; user-visible labels live in translations.
-    assert VIEW_OPTIONS == ["today", "tomorrow", "week", "two_weeks", "month"]
+    assert VIEW_OPTIONS == [
+        "today",
+        "tomorrow",
+        "today_tomorrow",
+        "week",
+        "work_week",
+        "two_weeks",
+        "month",
+    ]
     assert LAYOUT_OPTIONS == ["list", "agenda"]
 
 


### PR DESCRIPTION
## Highlights

This release rounds out the calendar card with a real **month view**, adds new
range options, makes chip cards configurable from the visual editor, and
refreshes the dev/test toolchain to HA 2026.4 / Python 3.14.

## New calendar layouts & views

- **Native month view** in `familyboard-calendar-card`: 6×7 grid with
  multi-member gradient pills, weather badges, today / other-month / weekend
  styling. Week rows grow to fit all events (no `+N more` truncation).
- **Multi-day events** render as continuous bars across the month grid
  (Google-Calendar style), with `‹` / `›` arrows on segments that continue
  into the previous/next week.
- **List layout** for the calendar card (selected via `layout_entity`):
  groups events by day with date number, weekday short name, weather chip,
  color bars and inline reminders. Pairs nicely with `familyboard-view-card`
  to toggle time-grid ↔ list in place.
- New range options: **`today_tomorrow`** (today + tomorrow side-by-side)
  and **`work_week`** (Mon–Fri). Wired through calendar / chores / list
  strategy + NL/EN translations.
- Week start now follows the HA user profile (`hass.locale.firstWeekday`)
  for week / 2-weeks / month grids; werkweek blijft ma–vr.
- `show_navigation: false` actually hides the prev/today/next buttons.

## Cards configurability

- `familyboard-view-card`: `hidden_options:` / `visible_options:` to
  whitelist or hide chips per dashboard, now exposed in the visual editor
  (only one is shown at a time to keep things unambiguous;
  `visible_options` wins when both are set).
- `familyboard-filter-card` and `familyboard-view-card`: new `alignment`
  option (`start` / `center` / `end` / `justify`, plus friendly aliases
  `left` / `middle` / `right` / `uitlijnen`), forwarded to the underlying
  `mushroom-chips-card` and exposed in each card's editor.

## Fixed

- Day-header date and weather chip no longer overlap in narrow / portrait
  week views — header is a flex row with container-query breakpoints that
  drop weather temperatures (and then the whole chip) as columns shrink.

## Tooling / CI

- Bumped dev deps to match HA 2026.4: `homeassistant` 2026.4.4,
  `pytest` ≥9.0.3, `pytest-asyncio` ≥1.3.0, `pytest-cov` ≥7.1.0,
  `pytest-homeassistant-custom-component` ≥0.13.324.
- CI: `actions/checkout@v6`, tests workflow on Python 3.14
  (required by the new `pytest-homeassistant-custom-component`).

## Closes

- #16 (calendar views & event rendering)
- #27 (native month view)
- #30 (list layout, alignment, portrait day-header fix)
- #31 (list layout & alignment merged)

Replaces the previously closed dependabot PRs #4–#9.