### PR TITLE
chore(deps): refresh dev deps and bump actions/checkout

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: HACS Action
         uses: hacs/action@main

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Hassfest
         uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 colorlog
-homeassistant==2026.2.3
+homeassistant==2026.4.4
 pip>=21.3.1
 ruff>=0.6.0
 -r requirements_test.txt

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
-pytest>=8.0.0
-pytest-asyncio>=0.23.0
-pytest-cov>=5.0.0
-pytest-homeassistant-custom-component>=0.13.190
+pytest>=9.0.3
+pytest-asyncio>=1.3.0
+pytest-cov>=7.1.0
+pytest-homeassistant-custom-component>=0.13.324
 ruff>=0.6.0


### PR DESCRIPTION
Applies the dependency bumps from the previously closed Dependabot PRs (#4-#9).

## Changes

- `homeassistant` 2026.2.3 → **2026.4.4** (matches `manifest.json` min HA 2026.4; closes the gap where the dev container was running an older HA than the integration declares)
- `pytest` >=8.0.0 → >=9.0.3
- `pytest-asyncio` >=0.23.0 → >=1.3.0 *(major bump — `asyncio_mode = "auto"` in `pyproject.toml` still works)*
- `pytest-cov` >=5.0.0 → >=7.1.0
- `pytest-homeassistant-custom-component` >=0.13.190 → >=0.13.324
- `actions/checkout@v5` → `@v6` in all four workflows (`codeql`, `hacs`, `hassfest`, `test`)

## Validation

- ☐ CI green on this branch (`test.yml`, `hassfest.yml`, `hacs.yml`, `codeql.yml`)
- ☐ Local `pytest` against the new `pytest-asyncio` 1.x — confirm fixtures still work
- ☐ Dev container rebuild picks up HA 2026.4.4