### PR TITLE
ci: bump tests workflow to Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: pip
 
       - name: Install dependencies


### PR DESCRIPTION
Follow-up to #28. The dev-deps refresh pinned `pytest-homeassistant-custom-component >=0.13.324`, but everything `>=0.13.317` requires Python 3.14 (HA 2026.4 minimum). The Tests workflow was still on 3.13, so the install step failed:

```
ERROR: Ignored the following versions that require a different python version: ... 0.13.324 Requires-Python >=3.14
ERROR: No matching distribution found for pytest-homeassistant-custom-component>=0.13.324
```

Bumps `actions/setup-python` to 3.14.