### PR TITLE
List layout, chip alignment, and portrait day-header fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `familyboard-calendar-card`: new **list** layout that groups events by day
+  (large date number, weekday short name, weather chip, color-bar per event,
+  reminders inline). Selected via the new `layout_entity` config option,
+  intended to be bound to `select.familyboard_layout` so the existing
+  `familyboard-view-card` toggles between time-grid and list in place.
+- `familyboard-filter-card` and `familyboard-view-card`: new `alignment`
+  config option (`start` / `center` / `end` / `justify`, with friendly
+  aliases `left` / `middle` / `right` / `uitlijnen`). Forwarded to the
+  underlying `mushroom-chips-card` and exposed in each card's visual editor.
+
+### Fixed
+- `familyboard-calendar-card`: day-header date and weather chip overlapped
+  on narrow widths (portrait week / 2-weeks view). Header is now a flex row
+  with container-query breakpoints that drop weather temperatures (then the
+  whole weather chip) when columns become too narrow.
+
 ## [0.1.0] - 2026-04-23
 
 Initial public release.

--- a/custom_components/familyboard/frontend/familyboard-calendar-card.js
+++ b/custom_components/familyboard/frontend/familyboard-calendar-card.js
@@ -103,6 +103,8 @@ class FamilyBoardCalendarCard extends HTMLElement {
       row_height: this._clampInt(config.row_height, 12, 80, 24),
       filter_entity: config.filter_entity || null,
       view_entity: config.view_entity || null,
+      layout_entity: config.layout_entity || null,
+      layout: config.layout === "list" ? "list" : "agenda",
       filter_map: config.filter_map || null,
       shared_calendars: sharedCalendars,
       member_entities: memberEntities,
@@ -230,6 +232,10 @@ class FamilyBoardCalendarCard extends HTMLElement {
       const s = hass.states[this._config.view_entity];
       parts.push(`v:${s ? s.state : "x"}`);
     }
+    if (this._config.layout_entity) {
+      const s = hass.states[this._config.layout_entity];
+      parts.push(`l:${s ? s.state : "x"}`);
+    }
     if (this._config.reminders_hide_when) {
       const s = hass.states[this._config.reminders_hide_when];
       parts.push(`rh:${s ? s.state : "x"}`);
@@ -297,6 +303,14 @@ class FamilyBoardCalendarCard extends HTMLElement {
       if (s && VIEW_FROM_SELECT[s.state]) return VIEW_FROM_SELECT[s.state];
     }
     return this._config.view;
+  }
+
+  _activeLayout() {
+    if (this._config.layout_entity && this._hass) {
+      const s = this._hass.states[this._config.layout_entity];
+      if (s && (s.state === "list" || s.state === "agenda")) return s.state;
+    }
+    return this._config.layout || "agenda";
   }
 
   _activeFilterValue() {
@@ -665,6 +679,7 @@ class FamilyBoardCalendarCard extends HTMLElement {
       this._wireBaseEvents();
     }
     const view = this._activeView();
+    const layout = this._activeLayout();
     const body = this.shadowRoot.querySelector(".fb-body");
     const title = this.shadowRoot.querySelector(".fb-title");
     title.textContent = this._headerTitle(view);
@@ -674,7 +689,9 @@ class FamilyBoardCalendarCard extends HTMLElement {
       return;
     }
 
-    if (view === "day") {
+    if (layout === "list") {
+      body.innerHTML = this._renderList(view);
+    } else if (view === "day") {
       body.innerHTML = this._renderTimeGrid(1);
     } else if (view === "week") {
       body.innerHTML = this._renderTimeGrid(7);
@@ -740,6 +757,7 @@ class FamilyBoardCalendarCard extends HTMLElement {
         display: grid;
         grid-template-columns: 56px 1fr;
         position: relative;
+        container-type: inline-size;
       }
       .fb-grid.cols-7 { grid-template-columns: 56px repeat(7, 1fr); }
       .fb-grid.cols-14 { grid-template-columns: 56px repeat(14, minmax(60px, 1fr)); overflow-x: auto; }
@@ -749,30 +767,54 @@ class FamilyBoardCalendarCard extends HTMLElement {
       }
       .fb-day-header {
         padding: 6px 8px;
-        text-align: center;
         border-bottom: 1px solid var(--fb-border);
         font-size: 0.85em;
         position: sticky; top: 0;
         background: var(--card-background-color, var(--ha-card-background, #1c1c1c));
         z-index: 3;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 6px;
+        min-width: 0;
       }
       .fb-day-header.today { color: var(--primary-color); font-weight: 600; }
       .fb-day-header .fb-dow { font-size: 0.75em; opacity: 0.7; }
       .fb-day-header .fb-dnum { font-size: 1.1em; }
-      .fb-day-header .fb-day-date { line-height: 1.15; }
+      .fb-day-header .fb-day-date {
+        line-height: 1.15;
+        text-align: left;
+        flex: 0 1 auto;
+        min-width: 0;
+      }
       .fb-day-wx {
-        position: absolute;
-        right: 8px;
-        top: 50%;
-        transform: translateY(-50%);
         display: inline-flex;
         align-items: center;
         gap: 4px;
         font-size: 0.85em;
         opacity: 0.95;
+        flex: 0 0 auto;
+        white-space: nowrap;
       }
       .fb-day-wx ha-icon { --mdc-icon-size: 20px; }
       .fb-day-wx .fb-wx-lo { opacity: 0.65; }
+      /* Narrow columns: drop temperatures, then drop weather entirely */
+      @container (max-width: 720px) {
+        .fb-grid.cols-7 .fb-day-wx .fb-wx-temps,
+        .fb-grid.cols-7 .fb-day-wx .fb-wx-hi,
+        .fb-grid.cols-7 .fb-day-wx .fb-wx-lo { display: none; }
+      }
+      @container (max-width: 1100px) {
+        .fb-grid.cols-14 .fb-day-wx .fb-wx-temps,
+        .fb-grid.cols-14 .fb-day-wx .fb-wx-hi,
+        .fb-grid.cols-14 .fb-day-wx .fb-wx-lo { display: none; }
+      }
+      @container (max-width: 480px) {
+        .fb-grid.cols-7 .fb-day-wx { display: none; }
+      }
+      @container (max-width: 780px) {
+        .fb-grid.cols-14 .fb-day-wx { display: none; }
+      }
 
       .fb-allday-row {
         display: contents;
@@ -917,6 +959,95 @@ class FamilyBoardCalendarCard extends HTMLElement {
         padding: 30px;
         text-align: center;
         color: var(--fb-muted);
+      }
+
+      /* List layout */
+      .fb-list { display: flex; flex-direction: column; }
+      .fb-list-day {
+        display: grid;
+        grid-template-columns: 64px 1fr;
+        gap: 8px;
+        padding: 8px 12px;
+        border-bottom: 1px solid var(--fb-border);
+        align-items: start;
+      }
+      .fb-list-day.today { background-color: rgba(255, 200, 0, 0.04); }
+      .fb-list-day-header {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: flex-start;
+        gap: 2px;
+        padding-top: 2px;
+      }
+      .fb-list-day-header .fb-list-day-num {
+        font-size: 1.8em;
+        font-weight: 300;
+        line-height: 1;
+      }
+      .fb-list-day-header .fb-list-day-name {
+        font-size: 0.75em;
+        opacity: 0.7;
+        text-transform: lowercase;
+      }
+      .fb-list-day.today .fb-list-day-num,
+      .fb-list-day.today .fb-list-day-name { color: var(--primary-color); font-weight: 500; }
+      .fb-list-day-header .fb-day-wx {
+        font-size: 0.75em;
+        opacity: 0.85;
+        margin-top: 2px;
+        flex-direction: column;
+        gap: 0;
+      }
+      .fb-list-day-header .fb-day-wx ha-icon { --mdc-icon-size: 18px; }
+      .fb-list-events {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        min-width: 0;
+      }
+      .fb-list-event {
+        display: flex;
+        align-items: stretch;
+        background: var(--fb-bg-alt);
+        border-radius: 4px;
+        overflow: hidden;
+        cursor: pointer;
+        min-height: 36px;
+      }
+      .fb-list-event:hover { filter: brightness(1.1); }
+      .fb-list-event-bar {
+        flex: 0 0 5px;
+        align-self: stretch;
+      }
+      .fb-list-event-body {
+        flex: 1;
+        min-width: 0;
+        padding: 4px 8px;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        gap: 2px;
+      }
+      .fb-list-event-time {
+        font-size: 0.72em;
+        opacity: 0.75;
+        line-height: 1.1;
+      }
+      .fb-list-event-title {
+        font-size: 0.95em;
+        font-weight: 500;
+        line-height: 1.2;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .fb-list-event.fb-reminder .fb-list-event-title { font-weight: 400; }
+      .fb-list-empty {
+        font-size: 0.85em;
+        color: var(--fb-muted);
+        font-style: italic;
+        padding: 4px 0;
       }
 
       .fb-empty {
@@ -1142,6 +1273,103 @@ class FamilyBoardCalendarCard extends HTMLElement {
 
   _renderMonthPlaceholder() {
     return `<div class="fb-month-placeholder">Maand-weergave komt in Phase 3.</div>`;
+  }
+
+  // ---------- list layout ----------
+
+  _renderList(view) {
+    const [start, end] = this._visibleRange();
+    const today = this._startOfDay(new Date());
+    const days = [];
+    for (let d = new Date(start); d < end; d = this._addDays(d, 1)) {
+      days.push(new Date(d));
+    }
+
+    // For month view, only render days that have events (avoids 30+ empty rows).
+    const skipEmpty = view === "month" || days.length > 14;
+
+    const reminders = this._buildReminderEvents();
+    const allEvents = [...this._events, ...reminders];
+
+    let html = `<div class="fb-list">`;
+    let rendered = 0;
+    for (const d of days) {
+      const dayAll = [];
+      const dayTimed = [];
+      for (const ev of allEvents) {
+        if (!this._eventOnDay(ev, d)) continue;
+        if (ev.allDay || this._spansFullDay(ev, d)) dayAll.push(ev);
+        else dayTimed.push(ev);
+      }
+      if (!dayAll.length && !dayTimed.length && skipEmpty) continue;
+      dayAll.sort((a, b) => (a.summary || "").localeCompare(b.summary || ""));
+      dayTimed.sort((a, b) => a.startDate - b.startDate);
+      html += this._renderListDay(d, dayAll, dayTimed, today);
+      rendered++;
+    }
+    if (!rendered) {
+      html += `<div class="fb-empty">Geen afspraken in deze periode.</div>`;
+    }
+    html += `</div>`;
+
+    const loading = this._loading ? `<div class="fb-loading">…</div>` : "";
+    const error = this._error ? `<div class="fb-error">⚠ ${this._error}</div>` : "";
+    return `${error}${loading}${html}`;
+  }
+
+  _renderListDay(date, allDay, timed, today) {
+    const cfg = this._config;
+    const isToday = this._isSameDay(date, today);
+    const dow = date.toLocaleDateString(cfg.locale, { weekday: "short" });
+    const wx = this._renderWeather(date);
+    const events = [...allDay, ...timed];
+    let eventsHtml;
+    if (events.length) {
+      eventsHtml = events.map((ev) => this._renderListEvent(ev, date)).join("");
+    } else {
+      eventsHtml = `<div class="fb-list-empty">Geen afspraken</div>`;
+    }
+    return `
+      <div class="fb-list-day${isToday ? " today" : ""}">
+        <div class="fb-list-day-header">
+          <div class="fb-list-day-num">${date.getDate()}</div>
+          <div class="fb-list-day-name">${dow}</div>
+          ${wx}
+        </div>
+        <div class="fb-list-events">${eventsHtml}</div>
+      </div>
+    `;
+  }
+
+  _renderListEvent(ev, day) {
+    const bg = this._eventBackground(ev);
+    const reminderCls = ev.isReminder ? " fb-reminder" : "";
+    const prefix = ev.isReminder ? "🔔 " : "";
+    const dataAttr = ev.isReminder
+      ? `data-todo="${this._escape(ev.todoEntity || "")}" data-uid="${this._escape(ev.uid || "")}"`
+      : `data-sources="${encodeURIComponent(JSON.stringify(ev.sources))}"`;
+    let timeLabel;
+    if (ev.allDay || this._spansFullDay(ev, day)) {
+      timeLabel = "Hele dag";
+    } else {
+      const dStart = this._startOfDay(day);
+      const dEnd = this._addDays(dStart, 1);
+      const startsToday = ev.startDate >= dStart;
+      const endsToday = ev.endDate <= dEnd;
+      const startStr = startsToday ? this._formatTime(ev.startDate) : "…";
+      const endStr = endsToday ? this._formatTime(ev.endDate) : "…";
+      timeLabel = `${startStr} – ${endStr}`;
+    }
+    const title = this._escape(ev.summary || "(geen titel)");
+    return `
+      <div class="fb-list-event${reminderCls}" ${dataAttr}>
+        <div class="fb-list-event-bar" style="background:${bg};"></div>
+        <div class="fb-list-event-body">
+          <div class="fb-list-event-time">${this._escape(timeLabel)}</div>
+          <div class="fb-list-event-title">${prefix}${title}</div>
+        </div>
+      </div>
+    `;
   }
 
   // Does the event overlap day d (00:00 - 24:00)?

--- a/custom_components/familyboard/frontend/familyboard-filter-card.js
+++ b/custom_components/familyboard/frontend/familyboard-filter-card.js
@@ -20,6 +20,26 @@ const DEFAULT_MEMBERS = "sensor.familyboard_members";
 const ALLES_LABEL = "Alles";
 const ALLES_COLOR = "#8c8c8c";
 
+// Accept friendly aliases for mushroom-chips-card `alignment` values.
+const ALIGNMENT_MAP = {
+  left: "start",
+  begin: "start",
+  start: "start",
+  middle: "center",
+  center: "center",
+  centre: "center",
+  right: "end",
+  end: "end",
+  uitlijnen: "justify",
+  justify: "justify",
+  spread: "justify",
+};
+
+function normalizeAlignment(v) {
+  if (!v) return null;
+  return ALIGNMENT_MAP[String(v).toLowerCase()] || null;
+}
+
 class FamilyBoardFilterCard extends HTMLElement {
   constructor() {
     super();
@@ -59,8 +79,11 @@ class FamilyBoardFilterCard extends HTMLElement {
       members_entity: config.members_entity || DEFAULT_MEMBERS,
       show_alles: config.show_alles !== false,
       extra_chips: Array.isArray(config.extra_chips) ? config.extra_chips : [],
+      alignment: normalizeAlignment(config.alignment),
       ...config,
     };
+    // Re-normalize after spread so `...config` can't reintroduce a raw alias.
+    this._config.alignment = normalizeAlignment(config.alignment);
   }
 
   set hass(hass) {
@@ -191,6 +214,7 @@ class FamilyBoardFilterCard extends HTMLElement {
       f: currentFilter,
       cfg: this._config.extra_chips.length,
       a: this._config.show_alles,
+      al: this._config.alignment || "",
     });
     if (sig === this._lastSig && this._inner) {
       this._inner.hass = this._hass;
@@ -200,6 +224,7 @@ class FamilyBoardFilterCard extends HTMLElement {
 
     const chips = this._buildChips(members, currentFilter);
     const cardConfig = { type: "custom:mushroom-chips-card", chips };
+    if (this._config.alignment) cardConfig.alignment = this._config.alignment;
 
     let helpers;
     try {
@@ -226,6 +251,20 @@ const FILTER_EDITOR_SCHEMA = [
   { name: "filter_entity", selector: { entity: { domain: "select" } } },
   { name: "members_entity", selector: { entity: { domain: "sensor" } } },
   { name: "show_alles", selector: { boolean: {} } },
+  {
+    name: "alignment",
+    selector: {
+      select: {
+        mode: "dropdown",
+        options: [
+          { value: "start", label: "Links" },
+          { value: "center", label: "Midden" },
+          { value: "end", label: "Rechts" },
+          { value: "justify", label: "Uitlijnen" },
+        ],
+      },
+    },
+  },
 ];
 
 class FamilyBoardFilterCardEditor extends HTMLElement {

--- a/custom_components/familyboard/frontend/familyboard-view-card.js
+++ b/custom_components/familyboard/frontend/familyboard-view-card.js
@@ -23,6 +23,26 @@
 const DEFAULT_ENTITY = "select.familyboard_view";
 const DEFAULT_REMINDERS_SWITCH = "switch.familyboard_show_reminders";
 
+// Accept friendly aliases for mushroom-chips-card `alignment` values.
+const ALIGNMENT_MAP = {
+  left: "start",
+  begin: "start",
+  start: "start",
+  middle: "center",
+  center: "center",
+  centre: "center",
+  right: "end",
+  end: "end",
+  uitlijnen: "justify",
+  justify: "justify",
+  spread: "justify",
+};
+
+function normalizeAlignment(v) {
+  if (!v) return null;
+  return ALIGNMENT_MAP[String(v).toLowerCase()] || null;
+}
+
 const DEFAULT_ICONS = {
   today: "mdi:calendar-today",
   tomorrow: "mdi:calendar-arrow-right",
@@ -75,8 +95,11 @@ class FamilyBoardViewCard extends HTMLElement {
       reminders_switch: config.reminders_switch || DEFAULT_REMINDERS_SWITCH,
       reminders_label: config.reminders_label || "Herinneringen",
       extra_chips: Array.isArray(config.extra_chips) ? config.extra_chips : [],
+      alignment: normalizeAlignment(config.alignment),
       ...config,
     };
+    // Re-normalize after spread so `...config` can't reintroduce a raw alias.
+    this._config.alignment = normalizeAlignment(config.alignment);
   }
 
   set hass(hass) {
@@ -175,6 +198,7 @@ class FamilyBoardViewCard extends HTMLElement {
       s: stateObj.state,
       lang: this._hass?.locale?.language || "",
       x: this._config.extra_chips.length,
+      a: this._config.alignment || "",
       r: this._config.show_reminders
         ? this._hass.states[this._config.reminders_switch]?.state || ""
         : "",
@@ -187,6 +211,7 @@ class FamilyBoardViewCard extends HTMLElement {
 
     const chips = this._buildChips(stateObj);
     const cardConfig = { type: "custom:mushroom-chips-card", chips };
+    if (this._config.alignment) cardConfig.alignment = this._config.alignment;
 
     let helpers;
     try {
@@ -214,6 +239,20 @@ const VIEW_EDITOR_SCHEMA = [
   { name: "color", selector: { text: {} } },
   { name: "show_reminders", selector: { boolean: {} } },
   { name: "reminders_switch", selector: { entity: { domain: "switch" } } },
+  {
+    name: "alignment",
+    selector: {
+      select: {
+        mode: "dropdown",
+        options: [
+          { value: "start", label: "Links" },
+          { value: "center", label: "Midden" },
+          { value: "end", label: "Rechts" },
+          { value: "justify", label: "Uitlijnen" },
+        ],
+      },
+    },
+  },
 ];
 
 class FamilyBoardViewCardEditor extends HTMLElement {


### PR DESCRIPTION
Closes #30.

## Summary

Three small but visible improvements to the FamilyBoard Lovelace cards, all driven by the kiosk-in-portrait use case:

1. **List layout for `familyboard-calendar-card`** — drops the dependency on `week-planner-card` + `config-template-card`. The same calendar card now toggles between the time-grid (agenda) and a grouped-by-day list, driven by a new `layout_entity` config option (intended to be bound to `select.familyboard_layout`).
2. **Day-header overlap fix** — on portrait week / 2-weeks view, the date number and weather chip used to collide. Header is now a flex row with container-query breakpoints that gracefully drop weather temperatures, then the whole chip, as columns narrow.
3. **Chip alignment on `familyboard-filter-card` and `familyboard-view-card`** — new `alignment:` option (`start` / `center` / `end` / `justify`, with friendly aliases `left` / `middle` / `right` / `uitlijnen`). Forwarded to `mushroom-chips-card` and exposed as a dropdown in both visual editors.

## Changes

- familyboard-calendar-card.js:
  - New `layout_entity` / `layout` config + `_activeLayout()` helper.
  - `_render()` branches on layout first; new `_renderList()` reuses `_visibleRange()`, `_buildReminderEvents()`, `_eventBackground()`, `_renderWeather()`, `_eventOnDay()`, `_spansFullDay()`, `_wireEventClicks()`.
  - List mode: all-day events first, then timed by start. "Geen afspraken" placeholder when range ≤ 14 days; month skips empty days.
  - Day-header CSS: flex row, `container-type: inline-size` on `.fb-grid`, container queries for graceful weather collapse.
- familyboard-filter-card.js and familyboard-view-card.js: `alignment` option, alias normalization, editor schema entry.
- CHANGELOG.md: `Added` + `Fixed` entries under `## [Unreleased]`.

## Verification

- `pytest` — 27/27 pass (no Python touched).
- Manually tested on the live kiosk:
  - Layout chip swaps the card in place between agenda/list, no re-fetch.
  - View chip cycles correctly: today / tomorrow → 1 day; week → 7 days; two_weeks → 14 days; month → only days with events.
  - Reminders show 🔔 and open the underlying todo; calendar events open more-info.
  - Filter chip still scopes events in list mode; member color stripe per event (gradient for shared multi-member events).
  - Portrait week view: date and weather no longer overlap; weather degrades icon-only → hidden as columns narrow.
  - `alignment` works in YAML and the visual editor for both filter and view cards.