### PR TITLE
Ask the Chef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-29
+
+### Added
+- Meal planning Phase 2.5: AI-assisted dinner suggestion. New
+  `meal_planner` config block (cuisines, pantry staples, restrictions,
+  per-weekday overrides, optional shopping list target) drives a
+  server-side prompt builder that calls `ai_task.generate_data`. Three
+  new services: `familyboard.suggest_meal` (with optional `date`),
+  `familyboard.accept_meal_suggestion`, and
+  `familyboard.clear_meal_suggestion`. New `sensor.familyboard_meal_suggestion`
+  exposes the latest suggestion (state = title, attrs = date / reason
+  / ingredients / generated_at). Dashboard chip "Maaltijd" opens a
+  popup with Vandaag/Morgen/Overmorgen quick picks and an Accept that
+  creates the calendar event and appends ingredients to the configured
+  shopping list. Suggestion persists across restarts.
+- Options-flow step **Maaltijdplanner (AI)** for editing the
+  `meal_planner` block from the UI (AI task entity, shopping list,
+  max minutes, cuisines / pantry / restrictions / extra notes — all
+  multi-line, one item per line). `day_overrides` remain YAML-only
+  for now and are preserved across UI edits.
+
 ## [0.2.1] - 2026-04-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -139,6 +139,22 @@ familyboard:
       members: [Person_1, Person_2]
       name: Groceries
   meal_calendar: calendar.meals
+  meal_planner:
+    ai_task_entity: ai_task.gpt_oss_20b   # required for suggest_meal
+    shopping_list: todo.groceries         # optional; ingredients land here on accept
+    cuisines: [Nederlands, Italiaans, Mexicaans, Aziatisch, Mediterraans]
+    pantry_staples: [zout, peper, olie, boter, ui, knoflook, kruiden,
+                     melk, eieren, rijst, pasta, sojasaus, ketjap,
+                     tomatenblik, bouillonblokjes]
+    restrictions:
+      - "Geen paprika"
+      - "Geen vis"
+    max_minutes: 30
+    day_overrides:
+      thursday:
+        note: "Training om 18:00 — kies iets heel makkelijks"
+        max_minutes: 15
+    extra_notes: ""
 ```
 
 ### Member options
@@ -194,6 +210,23 @@ familyboard:
 | `name` | no | — | Display name |
 | `color` | no | — | Color (hex) |
 
+### Meal planner options (`meal_planner`)
+
+Drives the AI dinner-suggestion service
+(`familyboard.suggest_meal`). All keys except `ai_task_entity` are
+optional; defaults are baked in.
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `ai_task_entity` | yes | — | `ai_task.*` entity that backs `ai_task.generate_data` |
+| `shopping_list` | no | — | `todo.*` entity ingredients are appended to on accept |
+| `cuisines` | no | NL/IT/MX/Asian/Med/ME | List of cuisines for variation hints. **User list replaces the default fully when set.** |
+| `pantry_staples` | no | sensible NL kitchen list | Items the model should NOT add to the shopping list. **User list replaces the default fully when set.** |
+| `restrictions` | no | `[]` | Hard rules ("Geen paprika", "Geen vis", …) |
+| `max_minutes` | no | `30` | Maximum total prep time hint |
+| `day_overrides` | no | `{}` | Per-weekday tweaks. Keys are lowercase English weekday names. Each entry may set `note` and/or `max_minutes`. |
+| `extra_notes` | no | `""` | Free-form text appended at the end of the prompt |
+
 ## Entities created
 
 ### Calendars
@@ -214,6 +247,7 @@ familyboard:
 | `sensor.familyboard_compliment` | Time-of-day greeting |
 | `sensor.familyboard_meals` | Tonight's meal + 7-day week strip (requires `meal_calendar`) |
 | `sensor.familyboard_recent_meals` | Top recent meal titles scored by usage and recency for the quick picker |
+| `sensor.familyboard_meal_suggestion` | Latest AI-generated dinner suggestion (state = title; attrs = `date`, `reason`, `ingredients`, `generated_at`) |
 | `binary_sensor.familyboard_meals_unplanned` | `on` when any of the next 7 days has no meal entry; placeholders count as planned |
 
 #### Meal placeholders

--- a/custom_components/familyboard/__init__.py
+++ b/custom_components/familyboard/__init__.py
@@ -26,6 +26,7 @@ from homeassistant.helpers import (
     device_registry as dr,
     entity_registry as er,
 )
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
@@ -47,11 +48,18 @@ from .const import (
     EVENT_TITLE_ENTITY,
     MEAL_LOOKAHEAD_DAYS,
     MEAL_RECENT_WINDOW_DAYS,
+    MEAL_SUGGESTION_STORAGE_KEY,
+    MEAL_SUGGESTION_STORAGE_VERSION,
     SCAN_INTERVAL_MINUTES,
     TASK_IDENTIFIER,
     VIEW_ENTITY,
 )
-from .helpers import is_meal_placeholder, member_calendar_entities, score_recent_meals
+from .helpers import (
+    build_meal_prompt,
+    is_meal_placeholder,
+    member_calendar_entities,
+    score_recent_meals,
+)
 from .reminder import ReminderManager
 from .schemas import OPTIONS_SCHEMA, default_options
 from .trash import TrashChoreManager
@@ -92,6 +100,11 @@ ADD_EVENT_SCHEMA = vol.Schema({})
 ADD_MEAL_SCHEMA = vol.Schema({})
 SNOOZE_TEST_SCHEMA = vol.Schema({vol.Required("uid"): cv.string})
 CANCEL_REMINDER_SCHEMA = vol.Schema({vol.Required("uid"): cv.string})
+SUGGEST_MEAL_SCHEMA = vol.Schema(
+    {vol.Optional("date"): cv.date, vol.Optional("ai_task_entity"): cv.entity_id}
+)
+ACCEPT_MEAL_SUGGESTION_SCHEMA = vol.Schema({})
+CLEAR_MEAL_SUGGESTION_SCHEMA = vol.Schema({})
 
 
 # ---------------------------------------------------------------------------
@@ -191,6 +204,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await _async_link_entities(hass, entry)
         await reminder_manager.async_start()
         await trash_chore_manager.async_start()
+        await coordinator.async_load_meal_suggestion()
         await coordinator.async_refresh()
         await _async_check_lovelace_dependencies(hass)
 
@@ -563,6 +577,172 @@ def _async_register_services(hass: HomeAssistant, conf: dict) -> None:
         uid = call.data["uid"]
         await manager.async_cancel(uid)
 
+    async def handle_suggest_meal(call: ServiceCall) -> None:
+        """Generate a meal suggestion via ``ai_task.generate_data``.
+
+        Uses the ``meal_planner`` options block for prompt configuration.
+        ``date`` defaults to today; ``ai_task_entity`` overrides the
+        configured one (one-shot, not persisted). Result is stored on the
+        coordinator and exposed via ``sensor.familyboard_meal_suggestion``.
+        """
+        planner = hass.data[DOMAIN]["config"].get("meal_planner") or {}
+        ai_entity = call.data.get("ai_task_entity") or planner.get("ai_task_entity")
+        if not ai_entity:
+            raise HomeAssistantError(
+                "Maaltijdplanner is niet geconfigureerd. Stel een AI-task "
+                "entiteit in via Instellingen \u2192 Apparaten \u2192 "
+                "FamilyBoard \u2192 Configureren \u2192 Maaltijdplanner (AI)."
+            )
+        if hass.states.get(ai_entity) is None:
+            raise HomeAssistantError(
+                f"AI-task entiteit '{ai_entity}' bestaat niet. Controleer "
+                "Instellingen \u2192 Apparaten \u2192 FamilyBoard \u2192 "
+                "Configureren \u2192 Maaltijdplanner (AI)."
+            )
+        target_date = call.data.get("date") or dt_util.now().date()
+
+        recent_items: list[dict] = []
+        week: list[dict] = []
+        coordinator: FamilyBoardCoordinator | None = hass.data.get(DOMAIN, {}).get(
+            "coordinator"
+        )
+        if coordinator and coordinator.data:
+            recent_items = list(coordinator.data.get("recent_meals") or [])
+            meals_by_date: dict[str, dict] = {}
+            for meal in coordinator.data.get("meals") or []:
+                meals_by_date.setdefault(meal["date"], meal)
+            today = dt_util.now().date()
+            for offset in range(MEAL_LOOKAHEAD_DAYS):
+                day = today + timedelta(days=offset)
+                iso = day.isoformat()
+                week.append(
+                    {
+                        "date": iso,
+                        "weekday": day.strftime("%A"),
+                        "meal": meals_by_date.get(iso),
+                    }
+                )
+
+        prompt = build_meal_prompt(
+            target_date,
+            planner=planner,
+            recent_items=recent_items,
+            week=week,
+        )
+
+        result = await hass.services.async_call(
+            "ai_task",
+            "generate_data",
+            {
+                "task_name": "FamilyBoard meal suggestion",
+                "entity_id": ai_entity,
+                "instructions": prompt,
+                "structure": {
+                    "title": {
+                        "description": "Naam van de maaltijd, max 4 woorden",
+                        "required": True,
+                        "selector": {"text": {}},
+                    },
+                    "reason": {
+                        "description": (
+                            "Korte reden (1 zin) waarom dit een goede keuze is"
+                        ),
+                        "required": True,
+                        "selector": {"text": {}},
+                    },
+                    "ingredients": {
+                        "description": (
+                            "Boodschappen, alleen losse strings, geen hoeveelheden"
+                        ),
+                        "required": True,
+                        "selector": {"text": {"multiple": True}},
+                    },
+                },
+            },
+            blocking=True,
+            return_response=True,
+        )
+
+        data = (result or {}).get("data") if isinstance(result, dict) else None
+        if not isinstance(data, dict):
+            raise HomeAssistantError(
+                f"ai_task.generate_data returned unexpected payload: {result!r}"
+            )
+
+        suggestion = {
+            "date": target_date.isoformat(),
+            "title": str(data.get("title") or "").strip(),
+            "reason": str(data.get("reason") or "").strip(),
+            "ingredients": [
+                str(i).strip()
+                for i in (data.get("ingredients") or [])
+                if str(i).strip()
+            ],
+            "generated_at": dt_util.utcnow().isoformat(),
+        }
+        if coordinator is not None:
+            await coordinator.async_set_meal_suggestion(suggestion)
+
+    async def handle_accept_meal_suggestion(call: ServiceCall) -> None:
+        """Apply the stored suggestion: create meal event + shopping items."""
+        coordinator: FamilyBoardCoordinator | None = hass.data.get(DOMAIN, {}).get(
+            "coordinator"
+        )
+        suggestion = coordinator.meal_suggestion if coordinator else None
+        if not suggestion or not suggestion.get("title"):
+            raise HomeAssistantError(
+                "Geen actieve maaltijdsuggestie. Tik eerst op Vandaag, "
+                "Morgen of Overmorgen om er een te genereren."
+            )
+
+        meal_calendar = hass.data[DOMAIN]["config"].get("meal_calendar")
+        if not meal_calendar:
+            raise HomeAssistantError(
+                "meal_calendar is niet geconfigureerd. Stel deze in via "
+                "FamilyBoard \u2192 Configureren \u2192 Algemene instellingen."
+            )
+
+        try:
+            target = _dt.fromisoformat(suggestion["date"]).date()
+        except (KeyError, ValueError) as err:
+            raise HomeAssistantError(f"Invalid suggestion date: {err}") from err
+
+        await hass.services.async_call(
+            "calendar",
+            "create_event",
+            {
+                "summary": suggestion["title"],
+                "start_date": target.isoformat(),
+                "end_date": (target + timedelta(days=1)).isoformat(),
+            },
+            target={"entity_id": meal_calendar},
+            blocking=True,
+        )
+
+        planner = hass.data[DOMAIN]["config"].get("meal_planner") or {}
+        shopping_list = planner.get("shopping_list")
+        if shopping_list:
+            for item in suggestion.get("ingredients", []):
+                await hass.services.async_call(
+                    "todo",
+                    "add_item",
+                    {"item": item},
+                    target={"entity_id": shopping_list},
+                    blocking=True,
+                )
+
+        if coordinator is not None:
+            await coordinator.async_set_meal_suggestion(None)
+            await coordinator.async_request_refresh()
+
+    async def handle_clear_meal_suggestion(call: ServiceCall) -> None:
+        """Discard the current meal suggestion without acting on it."""
+        coordinator: FamilyBoardCoordinator | None = hass.data.get(DOMAIN, {}).get(
+            "coordinator"
+        )
+        if coordinator is not None:
+            await coordinator.async_set_meal_suggestion(None)
+
     hass.services.async_register(
         DOMAIN, "add_event", handle_add_event, schema=ADD_EVENT_SCHEMA
     )
@@ -574,6 +754,21 @@ def _async_register_services(hass: HomeAssistant, conf: dict) -> None:
     )
     hass.services.async_register(
         DOMAIN, "cancel_reminder", handle_cancel_reminder, schema=CANCEL_REMINDER_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, "suggest_meal", handle_suggest_meal, schema=SUGGEST_MEAL_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "accept_meal_suggestion",
+        handle_accept_meal_suggestion,
+        schema=ACCEPT_MEAL_SUGGESTION_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "clear_meal_suggestion",
+        handle_clear_meal_suggestion,
+        schema=CLEAR_MEAL_SUGGESTION_SCHEMA,
     )
 
 
@@ -606,6 +801,27 @@ class FamilyBoardCoordinator(DataUpdateCoordinator):
         self._prev_active_uids: dict[str, set[str]] = {}
         self._daily_completed: dict[str, int] = {}
         self._progress_date: str = ""
+        self._meal_suggestion_store: Store = Store(
+            hass, MEAL_SUGGESTION_STORAGE_VERSION, MEAL_SUGGESTION_STORAGE_KEY
+        )
+        self._meal_suggestion: dict | None = None
+
+    async def async_load_meal_suggestion(self) -> None:
+        """Load the persisted meal suggestion from disk (call before refresh)."""
+        data = await self._meal_suggestion_store.async_load()
+        if isinstance(data, dict) and data.get("title"):
+            self._meal_suggestion = data
+
+    async def async_set_meal_suggestion(self, suggestion: dict | None) -> None:
+        """Persist a new (or cleared) meal suggestion and refresh listeners."""
+        self._meal_suggestion = suggestion
+        await self._meal_suggestion_store.async_save(suggestion or {})
+        await self.async_request_refresh()
+
+    @property
+    def meal_suggestion(self) -> dict | None:
+        """Return the current persisted meal suggestion, if any."""
+        return self._meal_suggestion
 
     async def async_fetch_events(
         self, entity_id: str, start_iso: str, end_iso: str
@@ -993,6 +1209,7 @@ class FamilyBoardCoordinator(DataUpdateCoordinator):
 
         result["meals"] = await self._fetch_meals(now)
         result["recent_meals"] = await self._fetch_recent_meals(now)
+        result["meal_suggestion"] = self._meal_suggestion
 
         return result
 

--- a/custom_components/familyboard/config_flow.py
+++ b/custom_components/familyboard/config_flow.py
@@ -20,6 +20,7 @@ import voluptuous as vol
 from .const import DEVICE_NAME, DOMAIN
 from .schemas import (
     EXTRA_CALENDAR_SCHEMA,
+    MEAL_PLANNER_SCHEMA,
     MEMBER_SCHEMA,
     OPTIONS_SCHEMA,
     SHARED_CALENDAR_SCHEMA,
@@ -150,6 +151,11 @@ def _normalize_options(
         meal = existing.get("meal_calendar")
     if meal:
         base["meal_calendar"] = meal
+    planner = raw.get("meal_planner")
+    if not planner and existing:
+        planner = existing.get("meal_planner")
+    if planner:
+        base["meal_planner"] = planner
     return base
 
 
@@ -207,6 +213,7 @@ class FamilyBoardOptionsFlow(config_entries.OptionsFlow):
                 "shared_calendars",
                 "shared_chores",
                 "general",
+                "meal_planner",
                 "save",
             ],
         )
@@ -238,6 +245,98 @@ class FamilyBoardOptionsFlow(config_entries.OptionsFlow):
                     ): _entity("calendar"),
                 }
             ),
+        )
+
+    async def async_step_meal_planner(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Edit the AI meal-planner configuration (Phase 2.5).
+
+        Multi-line text fields are split on newlines into a list. Empty
+        fields fall back to the defaults baked into ``const.py`` at
+        prompt-build time. ``day_overrides`` is preserved from the
+        existing options (YAML-only for v1).
+        """
+        existing = self._options.get("meal_planner") or {}
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            data: dict[str, Any] = {}
+            ai_entity = (user_input.get("ai_task_entity") or "").strip()
+            if not ai_entity:
+                # Empty submit clears the planner entirely.
+                self._options.pop("meal_planner", None)
+                return self.async_create_entry(title="", data=self._options)
+            data["ai_task_entity"] = ai_entity
+
+            shopping = (user_input.get("shopping_list") or "").strip()
+            if shopping:
+                data["shopping_list"] = shopping
+
+            max_min = user_input.get("max_minutes")
+            if max_min:
+                data["max_minutes"] = int(max_min)
+
+            for key in ("cuisines", "pantry_staples", "restrictions"):
+                items = _split_lines(user_input.get(key, ""))
+                if items:
+                    data[key] = items
+
+            extra_notes = (user_input.get("extra_notes") or "").strip()
+            if extra_notes:
+                data["extra_notes"] = extra_notes
+
+            # Preserve day_overrides set via YAML (no UI for v1).
+            if existing.get("day_overrides"):
+                data["day_overrides"] = existing["day_overrides"]
+
+            try:
+                validated = MEAL_PLANNER_SCHEMA(data)
+            except vol.Invalid as err:
+                errors["base"] = str(err)
+            else:
+                self._options["meal_planner"] = validated
+                return self.async_create_entry(title="", data=self._options)
+
+        return self.async_show_form(
+            step_id="meal_planner",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        "ai_task_entity",
+                        default=existing.get("ai_task_entity", ""),
+                    ): _entity("ai_task"),
+                    vol.Optional(
+                        "shopping_list",
+                        default=existing.get("shopping_list", ""),
+                    ): _entity("todo"),
+                    vol.Optional(
+                        "max_minutes",
+                        default=existing.get("max_minutes", 30),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=1, max=240, step=1, mode="box"
+                        )
+                    ),
+                    vol.Optional(
+                        "cuisines",
+                        default="\n".join(existing.get("cuisines") or []),
+                    ): _multiline(),
+                    vol.Optional(
+                        "pantry_staples",
+                        default="\n".join(existing.get("pantry_staples") or []),
+                    ): _multiline(),
+                    vol.Optional(
+                        "restrictions",
+                        default="\n".join(existing.get("restrictions") or []),
+                    ): _multiline(),
+                    vol.Optional(
+                        "extra_notes",
+                        default=existing.get("extra_notes", ""),
+                    ): _multiline(),
+                }
+            ),
+            errors=errors,
         )
 
     async def async_step_save(
@@ -748,6 +847,13 @@ def _strip_empties(data: dict[str, Any]) -> dict[str, Any]:
             continue
         out[k] = v
     return out
+
+
+def _split_lines(value: str | None) -> list[str]:
+    """Split a multi-line text field into a stripped list, dropping empties."""
+    if not value:
+        return []
+    return [line.strip() for line in value.splitlines() if line.strip()]
 
 
 __all__ = ["OPTIONS_SCHEMA", "FamilyBoardConfigFlow", "FamilyBoardOptionsFlow"]

--- a/custom_components/familyboard/const.py
+++ b/custom_components/familyboard/const.py
@@ -106,3 +106,39 @@ MEAL_PENALTY_ANCHORS: tuple[tuple[int, float], ...] = (
     (14, 1.0),
     (30, 0.0),
 )
+
+# Phase 2.5: AI-assisted meal suggestion
+MEAL_SUGGESTION_ENTITY = "sensor.familyboard_meal_suggestion"
+MEAL_SUGGESTION_STORAGE_KEY = "familyboard_meal_suggestion"
+MEAL_SUGGESTION_STORAGE_VERSION = 1
+MEAL_SUGGESTION_PLACEHOLDER = "Geen suggestie"
+# Bucket thresholds used by the prompt builder when classifying recent meals.
+MEAL_AVOID_DAYS = 14  # days_since < this → "recently eaten, do not suggest"
+MEAL_FAVORITE_DAYS = 21  # days_since >= this → "forgotten favorite, inspire"
+DEFAULT_MEAL_MAX_MINUTES = 30
+DEFAULT_MEAL_CUISINES: tuple[str, ...] = (
+    "Nederlands",
+    "Italiaans",
+    "Mexicaans",
+    "Aziatisch",
+    "Mediterraans",
+    "Midden-Oosters",
+)
+DEFAULT_MEAL_PANTRY: tuple[str, ...] = (
+    "zout",
+    "peper",
+    "olie",
+    "boter",
+    "ui",
+    "knoflook",
+    "kruiden",
+    "melk",
+    "eieren",
+    "rijst",
+    "pasta",
+    "sojasaus",
+    "ketjap",
+    "tomatenblik",
+    "bouillonblokjes",
+)
+DEFAULT_MEAL_RESTRICTIONS: tuple[str, ...] = ()

--- a/custom_components/familyboard/helpers.py
+++ b/custom_components/familyboard/helpers.py
@@ -6,7 +6,17 @@ from datetime import date as _date
 from itertools import pairwise
 from typing import Any
 
-from .const import MEAL_EMPTY_TITLES, MEAL_PENALTY_ANCHORS, MEAL_PICKER_LIMIT
+from .const import (
+    DEFAULT_MEAL_CUISINES,
+    DEFAULT_MEAL_MAX_MINUTES,
+    DEFAULT_MEAL_PANTRY,
+    DEFAULT_MEAL_RESTRICTIONS,
+    MEAL_AVOID_DAYS,
+    MEAL_EMPTY_TITLES,
+    MEAL_FAVORITE_DAYS,
+    MEAL_PENALTY_ANCHORS,
+    MEAL_PICKER_LIMIT,
+)
 
 
 def is_meal_placeholder(title: str | None) -> bool:
@@ -101,3 +111,156 @@ def member_calendar_entities(member: dict[str, Any]) -> list[tuple[str, str]]:
     for extra in member.get("extra_calendars", []):
         out.append((extra["label"], extra["entity"]))
     return out
+
+
+# ---------------------------------------------------------------------------
+# Meal suggestion prompt builder (Phase 2.5)
+# ---------------------------------------------------------------------------
+
+
+def _bucket_recent_meals(
+    items: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Split scored recent-meal items into (recently_eaten, forgotten_favorites).
+
+    ``recently_eaten`` = items with ``days_since < MEAL_AVOID_DAYS``,
+    sorted ascending by ``days_since`` (most recent first) — these are
+    the meals to AVOID re-suggesting.
+
+    ``forgotten_favorites`` = items with ``days_since >= MEAL_FAVORITE_DAYS``,
+    keeping the input order (which is score-desc) — these are inspiration.
+    """
+    recently: list[dict[str, Any]] = []
+    forgotten: list[dict[str, Any]] = []
+    for item in items:
+        days = item.get("days_since")
+        if days is None:
+            continue
+        if days < MEAL_AVOID_DAYS:
+            recently.append(item)
+        elif days >= MEAL_FAVORITE_DAYS:
+            forgotten.append(item)
+    recently.sort(key=lambda i: i["days_since"])
+    return recently, forgotten
+
+
+def build_meal_prompt(
+    target_date: _date,
+    *,
+    planner: dict[str, Any] | None,
+    recent_items: list[dict[str, Any]] | None = None,
+    week: list[dict[str, Any]] | None = None,
+) -> str:
+    """Render the AI meal-suggestion prompt for ``target_date``.
+
+    ``planner`` is the ``meal_planner`` options block (may be ``None``;
+    defaults are applied per missing key). ``recent_items`` mirrors the
+    ``items`` attribute of ``sensor.familyboard_recent_meals``. ``week``
+    mirrors the ``week`` attribute of ``sensor.familyboard_meals``; the
+    ``target_date`` entry is filtered out so the model does not see its
+    own slot as "already planned".
+    """
+    planner = planner or {}
+    cuisines = list(planner.get("cuisines") or DEFAULT_MEAL_CUISINES)
+    pantry = list(planner.get("pantry_staples") or DEFAULT_MEAL_PANTRY)
+    restrictions = list(planner.get("restrictions") or DEFAULT_MEAL_RESTRICTIONS)
+    max_minutes = planner.get("max_minutes") or DEFAULT_MEAL_MAX_MINUTES
+    overrides = planner.get("day_overrides") or {}
+    extra_notes = (planner.get("extra_notes") or "").strip()
+
+    weekday_en = target_date.strftime("%A")
+    override = overrides.get(weekday_en.lower()) or {}
+    if "max_minutes" in override:
+        max_minutes = override["max_minutes"]
+    day_note = (override.get("note") or "").strip()
+
+    target_iso = target_date.isoformat()
+    target_human = target_date.strftime("%A %d %B %Y")
+
+    recently_eaten, forgotten_favorites = _bucket_recent_meals(recent_items or [])
+
+    lines: list[str] = []
+    lines.append(
+        "Je bent een huiskok die avondmaaltijden plant voor een Nederlands gezin."
+    )
+    lines.append("")
+    lines.append("## Context")
+    lines.append(f"Doel-datum: {target_human}")
+    lines.append(f"Dag van de week: {weekday_en}")
+    lines.append("")
+
+    lines.append("## Recent gegeten — NIET opnieuw voorstellen")
+    if recently_eaten:
+        for m in recently_eaten[:10]:
+            lines.append(f"- {m['title']} ({m['days_since']}d geleden)")
+    else:
+        lines.append("- (geen)")
+    lines.append("")
+
+    lines.append("## Vergeten favorieten — overweeg deze als inspiratie")
+    if forgotten_favorites:
+        for m in forgotten_favorites[:8]:
+            lines.append(
+                f"- {m['title']} (laatst {m['days_since']}d geleden, "
+                f"{m['uses']}\u00d7 in 90d)"
+            )
+    else:
+        lines.append("- (geen)")
+    lines.append("")
+
+    lines.append("## Al gepland deze week (vermijd herhaling)")
+    week_lines: list[str] = []
+    for entry in week or []:
+        if entry.get("date") == target_iso:
+            continue
+        meal = entry.get("meal")
+        if not meal:
+            continue
+        title = meal.get("title") or ""
+        if not title or is_meal_placeholder(title):
+            continue
+        week_lines.append(f"- {entry['date']} ({entry.get('weekday', '')}): {title}")
+    if week_lines:
+        lines.extend(week_lines)
+    else:
+        lines.append("- (niets)")
+    lines.append("")
+
+    lines.append("## Harde regels")
+    for r in restrictions:
+        lines.append(f"- {r}")
+    lines.append(f"- Max {max_minutes} min totale bereidingstijd")
+    lines.append("- Gezinsvriendelijk, niet te pittig")
+    if cuisines:
+        lines.append(
+            "- Variatie in keukens is welkom: "
+            + ", ".join(cuisines)
+            + ". Wissel af; stel niet twee dagen achter elkaar dezelfde keuken voor."
+        )
+    if day_note:
+        lines.append(f"- {day_note}")
+    lines.append("")
+
+    lines.append("## Boodschappen-regel")
+    lines.append(
+        "Neem in `ingredients` ALLEEN producten op die normaal NIET in een "
+        "Nederlandse voorraadkast/koelkast liggen."
+    )
+    if pantry:
+        lines.append("Sla over: " + ", ".join(pantry) + ".")
+    lines.append(
+        'Geen hoeveelheden, geen merken, alleen het product (bv. "kipfilet", '
+        '"verse basilicum").'
+    )
+    lines.append("")
+
+    if extra_notes:
+        lines.append("## Extra")
+        lines.append(extra_notes)
+        lines.append("")
+
+    lines.append("## Output")
+    lines.append("Antwoord uitsluitend met de JSON-velden uit het schema.")
+    lines.append("Geen uitleg, geen recept, geen stappen.")
+
+    return "\n".join(lines)

--- a/custom_components/familyboard/manifest.json
+++ b/custom_components/familyboard/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/apiest/FamilyBoard/issues",
   "requirements": [],
-  "version": "0.2.1"
+  "version": "0.3.0"
 }

--- a/custom_components/familyboard/schemas.py
+++ b/custom_components/familyboard/schemas.py
@@ -60,6 +60,33 @@ SHARED_CHORE_SCHEMA = vol.Schema(
     }
 )
 
+# Phase 2.5: AI-assisted meal suggestion. ``ai_task_entity`` is the only
+# required field. ``day_overrides`` keys are lowercase English weekday
+# names (``monday``..``sunday``).
+DAY_OVERRIDE_SCHEMA = vol.Schema(
+    {
+        vol.Optional("note"): cv.string,
+        vol.Optional("max_minutes"): vol.All(int, vol.Range(min=1, max=240)),
+    }
+)
+
+MEAL_PLANNER_SCHEMA = vol.Schema(
+    {
+        vol.Required("ai_task_entity"): cv.entity_id,
+        vol.Optional("shopping_list"): cv.entity_id,
+        vol.Optional("cuisines", default=[]): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional("pantry_staples", default=[]): vol.All(
+            cv.ensure_list, [cv.string]
+        ),
+        vol.Optional("restrictions", default=[]): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional("max_minutes"): vol.All(int, vol.Range(min=1, max=240)),
+        vol.Optional("day_overrides", default={}): vol.Schema(
+            {cv.string: DAY_OVERRIDE_SCHEMA}
+        ),
+        vol.Optional("extra_notes", default=""): cv.string,
+    }
+)
+
 OPTIONS_SCHEMA = vol.Schema(
     {
         vol.Required("members", default=[]): vol.All(cv.ensure_list, [MEMBER_SCHEMA]),
@@ -71,6 +98,7 @@ OPTIONS_SCHEMA = vol.Schema(
             cv.ensure_list, [SHARED_CHORE_SCHEMA]
         ),
         vol.Optional("meal_calendar"): cv.entity_id,
+        vol.Optional("meal_planner"): MEAL_PLANNER_SCHEMA,
     }
 )
 

--- a/custom_components/familyboard/sensor.py
+++ b/custom_components/familyboard/sensor.py
@@ -27,6 +27,7 @@ from .const import (
     DOMAIN,
     MEAL_LOOKAHEAD_DAYS,
     MEAL_PLACEHOLDER,
+    MEAL_SUGGESTION_PLACEHOLDER,
     get_device_info,
 )
 
@@ -48,6 +49,7 @@ async def async_setup_entry(
             FamilyBoardComplimentSensor(),
             FamilyBoardMealsSensor(coordinator, conf),
             FamilyBoardRecentMealsSensor(coordinator, conf),
+            FamilyBoardMealSuggestionSensor(coordinator),
             FamilyBoardMembersSensor(coordinator),
             FamilyBoardProgressSensor(coordinator),
         ],
@@ -310,4 +312,52 @@ class FamilyBoardRecentMealsSensor(CoordinatorEntity, SensorEntity):
         return {
             "items": self._items(),
             "meal_calendar_entity": self._conf.get("meal_calendar"),
+        }
+
+
+class FamilyBoardMealSuggestionSensor(CoordinatorEntity, SensorEntity):
+    """Sensor exposing the latest AI meal suggestion (Phase 2.5).
+
+    State is the suggested meal title (or
+    :data:`MEAL_SUGGESTION_PLACEHOLDER` when no suggestion exists).
+    Attributes carry the full structured suggestion (``date``,
+    ``reason``, ``ingredients``, ``generated_at``) so the dashboard
+    can render the popup and the accept-action.
+    """
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "meal_suggestion"
+
+    def __init__(self, coordinator: DataUpdateCoordinator) -> None:
+        """Store the coordinator."""
+        super().__init__(coordinator)
+        self._attr_unique_id = "familyboard_meal_suggestion"
+        self._attr_suggested_object_id = "familyboard_meal_suggestion"
+        self._attr_icon = "mdi:chef-hat"
+        self._attr_device_info = get_device_info()
+
+    def _suggestion(self) -> dict | None:
+        """Return the stored suggestion dict from the coordinator."""
+        if not self.coordinator.data:
+            return None
+        return self.coordinator.data.get("meal_suggestion")
+
+    @property
+    def native_value(self) -> str:
+        """Return the suggested title or the empty placeholder."""
+        s = self._suggestion()
+        if s and s.get("title"):
+            return s["title"]
+        return MEAL_SUGGESTION_PLACEHOLDER
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Expose the full suggestion payload for the popup card."""
+        s = self._suggestion() or {}
+        return {
+            "date": s.get("date"),
+            "title": s.get("title"),
+            "reason": s.get("reason"),
+            "ingredients": s.get("ingredients") or [],
+            "generated_at": s.get("generated_at"),
         }

--- a/custom_components/familyboard/services.yaml
+++ b/custom_components/familyboard/services.yaml
@@ -42,3 +42,37 @@ cancel_reminder:
       example: "RE5QaTNIeEhaLS1xQm83OA"
       selector:
         text:
+
+suggest_meal:
+  name: Suggest meal
+  description: >-
+    Generate a meal suggestion via ai_task.generate_data using the
+    configured meal_planner block. Stores the result on
+    sensor.familyboard_meal_suggestion.
+  fields:
+    date:
+      name: Target date
+      description: The date the meal is for. Defaults to today.
+      example: "2026-04-30"
+      selector:
+        date:
+    ai_task_entity:
+      name: AI task entity
+      description: >-
+        One-shot override of the configured ai_task_entity. Useful to
+        try a different model without changing options.
+      example: ai_task.gpt_oss_20b
+      selector:
+        entity:
+          domain: ai_task
+
+accept_meal_suggestion:
+  name: Accept meal suggestion
+  description: >-
+    Apply the stored suggestion: create an all-day event on the
+    configured meal_calendar for its date and append each ingredient to
+    the configured shopping_list (when set).
+
+clear_meal_suggestion:
+  name: Clear meal suggestion
+  description: Discard the current meal suggestion without acting on it.

--- a/custom_components/familyboard/translations/en.json
+++ b/custom_components/familyboard/translations/en.json
@@ -21,6 +21,7 @@
           "shared_calendars": "Shared calendars",
           "shared_chores": "Shared chores",
           "general": "General settings",
+          "meal_planner": "Meal planner (AI)",
           "save": "Save and exit"
         }
       },
@@ -111,6 +112,19 @@
         "data": {
           "meal_calendar": "Meal calendar"
         }
+      },
+      "meal_planner": {
+        "title": "Meal planner (AI)",
+        "description": "Configure the AI suggestion. Empty fields use sensible defaults. One item per line.",
+        "data": {
+          "ai_task_entity": "AI task entity (required)",
+          "shopping_list": "Shopping list (todo)",
+          "max_minutes": "Maximum prep time (min)",
+          "cuisines": "Cuisines (one per line)",
+          "pantry_staples": "Pantry staples (one per line)",
+          "restrictions": "Restrictions (one per line)",
+          "extra_notes": "Extra instructions (free text)"
+        }
       }
     },
     "error": {
@@ -127,6 +141,7 @@
       "compliment": { "name": "Greeting" },
       "meals": { "name": "Meals" },
       "recent_meals": { "name": "Recent meals" },
+      "meal_suggestion": { "name": "Meal suggestion" },
       "members": { "name": "Members" },
       "progress": { "name": "Progress" }
     },
@@ -197,6 +212,28 @@
           "description": "The Google Tasks uid of the reminder to cancel."
         }
       }
+    },
+    "suggest_meal": {
+      "name": "Suggest meal",
+      "description": "Generate a meal suggestion via ai_task.generate_data and store it on sensor.familyboard_meal_suggestion.",
+      "fields": {
+        "date": {
+          "name": "Target date",
+          "description": "The date the meal is for. Defaults to today."
+        },
+        "ai_task_entity": {
+          "name": "AI task entity",
+          "description": "One-shot override of the configured ai_task_entity."
+        }
+      }
+    },
+    "accept_meal_suggestion": {
+      "name": "Accept suggestion",
+      "description": "Plan the current suggestion as a meal_calendar event and append ingredients to the shopping list."
+    },
+    "clear_meal_suggestion": {
+      "name": "Clear suggestion",
+      "description": "Discard the current meal suggestion without acting on it."
     }
   }
 }

--- a/custom_components/familyboard/translations/nl.json
+++ b/custom_components/familyboard/translations/nl.json
@@ -21,6 +21,7 @@
           "shared_calendars": "Gedeelde agenda's",
           "shared_chores": "Gedeelde taken",
           "general": "Algemene instellingen",
+          "meal_planner": "Maaltijdplanner (AI)",
           "save": "Opslaan en sluiten"
         }
       },
@@ -111,6 +112,19 @@
         "data": {
           "meal_calendar": "Maaltijdenagenda"
         }
+      },
+      "meal_planner": {
+        "title": "Maaltijdplanner (AI)",
+        "description": "Configureer de AI-suggestie. Lege velden gebruiken de standaardwaarden. Geef één item per regel.",
+        "data": {
+          "ai_task_entity": "AI-task entiteit (verplicht)",
+          "shopping_list": "Boodschappenlijst (todo)",
+          "max_minutes": "Maximale bereidingstijd (min)",
+          "cuisines": "Keukens (één per regel)",
+          "pantry_staples": "Voorraadkast-items (één per regel)",
+          "restrictions": "Restricties (één per regel)",
+          "extra_notes": "Extra instructies (vrije tekst)"
+        }
       }
     },
     "error": {
@@ -127,6 +141,7 @@
       "compliment": { "name": "Begroeting" },
       "meals": { "name": "Maaltijden" },
       "recent_meals": { "name": "Recente maaltijden" },
+      "meal_suggestion": { "name": "Maaltijdsuggestie" },
       "members": { "name": "Leden" },
       "progress": { "name": "Voortgang" }
     },
@@ -197,6 +212,28 @@
           "description": "De Google Tasks uid van de herinnering die geannuleerd moet worden."
         }
       }
+    },
+    "suggest_meal": {
+      "name": "Maaltijd voorstellen",
+      "description": "Genereer een maaltijdsuggestie via ai_task.generate_data en sla deze op in sensor.familyboard_meal_suggestion.",
+      "fields": {
+        "date": {
+          "name": "Doel-datum",
+          "description": "De datum waarvoor de maaltijd is. Standaard vandaag."
+        },
+        "ai_task_entity": {
+          "name": "AI-task entiteit",
+          "description": "Eenmalige override van de geconfigureerde ai_task_entity."
+        }
+      }
+    },
+    "accept_meal_suggestion": {
+      "name": "Suggestie accepteren",
+      "description": "Plant de huidige suggestie als event op meal_calendar en voegt ingrediënten toe aan de boodschappenlijst."
+    },
+    "clear_meal_suggestion": {
+      "name": "Suggestie verwijderen",
+      "description": "Verwijder de huidige maaltijdsuggestie zonder actie."
     }
   }
 }

--- a/tests/test_meal_prompt.py
+++ b/tests/test_meal_prompt.py
@@ -1,0 +1,153 @@
+"""Tests for the meal-suggestion prompt builder."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from custom_components.familyboard.helpers import (
+    _bucket_recent_meals,
+    build_meal_prompt,
+)
+
+
+def _items() -> list[dict]:
+    """Return a synthetic recent-meals attribute list."""
+    return [
+        {"title": "Spaghetti", "uses": 5, "days_since": 2, "score": 4.0},
+        {"title": "Wraps", "uses": 3, "days_since": 12, "score": 2.0},
+        {"title": "Stamppot", "uses": 6, "days_since": 25, "score": 6.0},
+        {"title": "Risotto", "uses": 4, "days_since": 40, "score": 4.0},
+    ]
+
+
+def test_bucket_recent_meals_split() -> None:
+    """Items <14d → recently_eaten asc; >=21d → forgotten_favorites."""
+    recently, forgotten = _bucket_recent_meals(_items())
+    assert [i["title"] for i in recently] == ["Spaghetti", "Wraps"]
+    assert {i["title"] for i in forgotten} == {"Stamppot", "Risotto"}
+
+
+def test_bucket_drops_middle_band() -> None:
+    """Items in 14..20d range fall into neither bucket."""
+    recently, forgotten = _bucket_recent_meals(
+        [{"title": "Mid", "uses": 1, "days_since": 17, "score": 1.0}]
+    )
+    assert recently == []
+    assert forgotten == []
+
+
+def test_prompt_defaults_smoke() -> None:
+    """Default planner produces a structured prompt with all sections."""
+    prompt = build_meal_prompt(date(2026, 4, 29), planner=None, recent_items=_items())
+    assert "## Context" in prompt
+    assert "Doel-datum: Wednesday 29 April 2026" in prompt
+    assert "## Recent gegeten" in prompt
+    assert "- Spaghetti (2d geleden)" in prompt
+    assert "## Vergeten favorieten" in prompt
+    assert "Stamppot" in prompt
+    # Default cuisines + max_minutes appear
+    assert "Max 30 min" in prompt
+    assert "Nederlands" in prompt
+    # Pantry default appears
+    assert "rijst" in prompt
+    # Output contract present
+    assert "## Output" in prompt
+
+
+def test_prompt_custom_cuisines_replace_default() -> None:
+    """User-provided cuisines fully replace the default list."""
+    prompt = build_meal_prompt(
+        date(2026, 4, 29),
+        planner={
+            "ai_task_entity": "ai_task.foo",
+            "cuisines": ["Frans", "Spaans"],
+        },
+    )
+    assert "Frans" in prompt
+    assert "Spaans" in prompt
+    assert "Italiaans" not in prompt
+
+
+def test_prompt_day_override_thursday() -> None:
+    """Day override on target weekday adjusts max_minutes and adds note."""
+    prompt = build_meal_prompt(
+        date(2026, 4, 30),  # Thursday
+        planner={
+            "ai_task_entity": "ai_task.foo",
+            "day_overrides": {
+                "thursday": {
+                    "note": "Training om 18:00 — heel makkelijk",
+                    "max_minutes": 15,
+                }
+            },
+        },
+    )
+    assert "Max 15 min" in prompt
+    assert "Training om 18:00" in prompt
+    assert "Max 30 min" not in prompt
+
+
+def test_prompt_day_override_other_weekday_not_applied() -> None:
+    """Day override only applies on its weekday key."""
+    prompt = build_meal_prompt(
+        date(2026, 4, 29),  # Wednesday
+        planner={
+            "ai_task_entity": "ai_task.foo",
+            "day_overrides": {"thursday": {"max_minutes": 15}},
+        },
+    )
+    assert "Max 30 min" in prompt
+    assert "Max 15 min" not in prompt
+
+
+def test_prompt_target_date_excluded_from_week() -> None:
+    """The target date's own slot is filtered out of the planned-week list."""
+    week = [
+        {"date": "2026-04-29", "weekday": "Wednesday", "meal": {"title": "Pizza"}},
+        {"date": "2026-04-30", "weekday": "Thursday", "meal": {"title": "Soep"}},
+    ]
+    prompt = build_meal_prompt(
+        date(2026, 4, 29),
+        planner={"ai_task_entity": "ai_task.foo"},
+        week=week,
+    )
+    assert "Soep" in prompt
+    assert "Pizza" not in prompt
+
+
+def test_prompt_skips_placeholder_meals_in_week() -> None:
+    """Placeholder titles in the week list are filtered out."""
+    week = [
+        {"date": "2026-04-30", "weekday": "Thursday", "meal": {"title": "-"}},
+        {"date": "2026-05-01", "weekday": "Friday", "meal": None},
+    ]
+    prompt = build_meal_prompt(
+        date(2026, 4, 29),
+        planner={"ai_task_entity": "ai_task.foo"},
+        week=week,
+    )
+    assert "(niets)" in prompt
+
+
+def test_prompt_extra_notes_appended() -> None:
+    """extra_notes block appears verbatim before the Output section."""
+    prompt = build_meal_prompt(
+        date(2026, 4, 29),
+        planner={
+            "ai_task_entity": "ai_task.foo",
+            "extra_notes": "Sylvia is vandaag niet thuis.",
+        },
+    )
+    assert "Sylvia is vandaag niet thuis." in prompt
+    assert prompt.index("Sylvia") < prompt.index("## Output")
+
+
+def test_prompt_empty_recent_items() -> None:
+    """Falls back to '(geen)' when no recent items are available."""
+    prompt = build_meal_prompt(
+        date(2026, 4, 29),
+        planner={"ai_task_entity": "ai_task.foo"},
+        recent_items=[],
+    )
+    # Both buckets render a "(geen)" placeholder
+    assert prompt.count("(geen)") == 2


### PR DESCRIPTION
# feat: AI-assisted dinner suggestion (Meal Planning Phase 2.5)

Adds a one-tap "what's for dinner?" flow on top of the existing
`calendar.meals` and `sensor.familyboard_recent_meals` foundations.
Fully config-driven, server-side prompt rendering, no script-level
Jinja required.

## What's new

- **`meal_planner` config block** with sensible defaults (cuisines,
  pantry staples, restrictions, per-weekday overrides, optional
  shopping list target). Required: `ai_task_entity`. All other keys
  optional.
- **Options-flow step "Maaltijdplanner (AI)"** for full UI editing
  (multi-line textareas, one item per line, empty = defaults).
  `day_overrides` remain YAML-only for v1 and are preserved across
  UI saves.
- **Three new services:**
  - `familyboard.suggest_meal(date?, ai_task_entity?)` — builds the
    Dutch prompt from config + recent-meals + week, calls
    `ai_task.generate_data` with a flat schema (title / reason /
    ingredients), persists the result.
  - `familyboard.accept_meal_suggestion()` — creates the meal event
    on `meal_calendar` for the suggested date and appends each
    ingredient to the configured `shopping_list`.
  - `familyboard.clear_meal_suggestion()` — discards without acting.
- **`sensor.familyboard_meal_suggestion`** — state = title, attrs =
  `date` / `reason` / `ingredients` / `generated_at`. Persisted via
  `Store('familyboard_meal_suggestion')` and restored on startup.
- **Dashboard:** new "Maaltijd" mushroom chip opens a Bubble pop-up
  with Vandaag / Morgen / Overmorgen quick picks, the rendered
  suggestion, and Plan / Wis actions.

## Prompt builder design

`helpers.build_meal_prompt(target_date, planner, recent_items, week)`
is a pure function (testable, no HA imports). It splits the
`recent_meals` sensor items into two buckets:

- `recently_eaten` (`days_since < 14`, asc) → "do not suggest"
- `forgotten_favorites` (`days_since >= 21`, score desc) → inspiration

The target date is filtered out of the "already planned this week"
list so the model doesn't see its own slot as taken. Day-overrides
(e.g. Thursday training night) apply to the target date's weekday,
not today's.

## Friendly errors

`suggest_meal` and `accept_meal_suggestion` raise actionable
Dutch `HomeAssistantError` messages when the planner isn't
configured, the AI task entity is missing, or there's no
suggestion to accept — surfacing as toasts in the UI rather than
silent failures.

## Files

- `custom_components/familyboard/{schemas,const,helpers,sensor,__init__,config_flow,services,text}.py`
- `custom_components/familyboard/translations/{en,nl}.json`
- `custom_components/familyboard/services.yaml`
- `dashboards/familyboard.yaml`
- `tests/test_meal_prompt.py` (10 new tests)
- `README.md`, `CHANGELOG.md`, `plans/meals.md`

## Verification

- `ruff check` + `ruff format --check` clean
- `pytest` 37/37 green
- Manual: dev container w/ `gpt-oss:20b` via Ollama returns
  schema-conformant dict; suggestion survives HA restart;
  Vandaag/Morgen/Overmorgen pickers create events on the right date;
  ingredients land on the configured shopping list.

## Out of scope (Phase 3)

- Conversational tool-calling agent ("plan dinsdag t/m donderdag")
- Recipe knowledge base under `/config/recipes/`
- Per-member `dislikes` / `diet` fields
- `day_overrides` UI editor

## Related

Refs #20 — partial groundwork for the AI orchestrator. This PR ships
the one-shot suggestion path (no tool calling, no recipe KB, no
multi-day planning). The full orchestrator from #20 remains open and
will build on:

- the `meal_planner` config block (already covers `ai_task_entity`,
  `shopping_list`, restrictions, day overrides)
- the prompt-builder splitting recent meals into avoid / inspiration
  buckets
- the suggestion sensor + storage pattern for persistence

Phase 3 still needs: stack decision, recipe KB loader,
per-member `dislikes`/`diet`, `text.familyboard_meal_query`,
`prompts/meal_planner.md`, and `conversation.process` wiring with
exposed tools.