### PR TITLE
feat: add show_shared option to familyboard-chores-card for filtering…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `familyboard-chores-card`: new `show_shared` option (default `true`) to hide
+  shared ("algemene") chores, and a `member: shared` value that turns the
+  card into a shared-only view with an "Algemene taken" header. The card
+  editor exposes `member` as a dropdown of configured family members plus an
+  "Algemene (gedeeld)" option.
+
 ## [0.2.1] - 2026-04-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -292,7 +292,15 @@ entity: sensor.familyboard_chores
 filter_entity: select.familyboard_calendar
 view_entity: select.familyboard_view
 members_entity: sensor.familyboard_members
+# Optional:
+#   member: Person_1     # bind card to one member (or 'shared' for the algemene list)
+#   show_shared: false   # hide shared chores from a personal/all view
+#   show_header: false   # hide the member/shared header
 ```
+
+Set `member: shared` to render only the shared ("algemene") chores; the
+`filter_entity` member chips and the `show_shared` toggle are ignored in that
+mode. The view filter (`view_entity`) still scopes the date window.
 
 ## Dashboard options
 

--- a/custom_components/familyboard/frontend/familyboard-chores-card.js
+++ b/custom_components/familyboard/frontend/familyboard-chores-card.js
@@ -46,11 +46,18 @@ class FamilyBoardChoresCard extends HTMLElement {
       member: config.member || null,
       members_entity: config.members_entity || "sensor.familyboard_members",
       show_header: config.show_header !== false,
+      show_shared: config.show_shared !== false,
       ...config,
     };
   }
 
+  _isSharedMode() {
+    return this._config.member === "shared";
+  }
+
   _isVisible() {
+    // Shared-only cards are always visible regardless of filter
+    if (this._isSharedMode()) return true;
     // When member is configured, hide card if filter excludes that member
     if (!this._config.member) return true;
     if (!this._config.filter_entity || !this._hass) return true;
@@ -91,14 +98,24 @@ class FamilyBoardChoresCard extends HTMLElement {
       }
     }
 
+    // Shared-only mode: ignore member/filter logic and show_shared toggle
+    if (this._isSharedMode()) {
+      return items.filter((i) => i.shared);
+    }
+
+    const dropShared = (list) =>
+      this._config.show_shared === false ? list.filter((i) => !i.shared) : list;
+
     // Hard member filter: when card is bound to a member, always show only that member
     if (this._config.member) {
       const m = this._config.member;
-      return items.filter((i) => {
-        if (i.member === m) return true;
-        if (i.shared && i.shared_members && i.shared_members.includes(m)) return true;
-        return false;
-      });
+      return dropShared(
+        items.filter((i) => {
+          if (i.member === m) return true;
+          if (i.shared && i.shared_members && i.shared_members.includes(m)) return true;
+          return false;
+        }),
+      );
     }
 
     // Apply member filter from filter_entity
@@ -107,18 +124,20 @@ class FamilyBoardChoresCard extends HTMLElement {
       if (filterState) {
         const filter = filterState.state;
         if (filter === "Alles") {
-          return items;
+          return dropShared(items);
         }
         // Member filter: include personal chores + shared chores where member is listed
-        return items.filter((i) => {
-          if (i.member === filter) return true;
-          if (i.shared && i.shared_members && i.shared_members.includes(filter)) return true;
-          return false;
-        });
+        return dropShared(
+          items.filter((i) => {
+            if (i.member === filter) return true;
+            if (i.shared && i.shared_members && i.shared_members.includes(filter)) return true;
+            return false;
+          }),
+        );
       }
     }
 
-    return items;
+    return dropShared(items);
   }
 
   _filterByView(items, view) {
@@ -260,16 +279,17 @@ class FamilyBoardChoresCard extends HTMLElement {
     this.style.display = "";
 
     const items = this._getFilteredItems();
-    const memberMeta = this._config.member ? this._getMemberMeta(this._config.member) : null;
-    const memberColor = memberMeta?.color || "#4A90D9";
+    const sharedMode = this._isSharedMode();
+    const memberMeta = this._config.member && !sharedMode ? this._getMemberMeta(this._config.member) : null;
+    const memberColor = sharedMode ? "#8b949e" : memberMeta?.color || "#4A90D9";
     const memberPic = memberMeta?.picture || "";
 
     // Determine "active member" for shared-chore badge override:
-    // 1. Explicit `member` config wins
+    // 1. Explicit `member` config wins (unless shared mode)
     // 2. Else, when filter_entity is set to a specific member name (not "Alles"), use that
-    let activeMember = this._config.member || null;
+    let activeMember = sharedMode ? null : this._config.member || null;
     let activeMemberMeta = memberMeta;
-    if (!activeMember && this._config.filter_entity) {
+    if (!sharedMode && !activeMember && this._config.filter_entity) {
       const fs = this._hass.states[this._config.filter_entity];
       if (fs && fs.state && fs.state !== "Alles") {
         activeMember = fs.state;
@@ -475,7 +495,15 @@ class FamilyBoardChoresCard extends HTMLElement {
 
     let html = `<style>${style}</style><div class="card" style="--fb-member-color: ${this._escAttr(memberColor)}">`;
 
-    if (this._config.member && this._config.show_header) {
+    if (sharedMode && this._config.show_header) {
+      html += `
+        <div class="member-header">
+          <div class="avatar">👥</div>
+          <div class="name">Algemene taken</div>
+          <div class="count">${items.length} ${items.length === 1 ? "taak" : "taken"}</div>
+        </div>
+      `;
+    } else if (this._config.member && this._config.show_header) {
       const initial = (this._config.member || "?")[0];
       const avatar = memberPic
         ? `<img src="${this._escAttr(memberPic)}" alt="${this._esc(initial)}">`
@@ -525,11 +553,13 @@ class FamilyBoardChoresCard extends HTMLElement {
 
         const initial = (item.member || "?")[0];
         const pic = item.picture || "";
-        // For shared chores when an active member is known, show that member's avatar/color
+        // For shared chores when an active member is known, show that member's avatar/color.
+        // In shared-only mode we hide the badge entirely — the header already
+        // says "Algemene taken" so per-row member icons add no information.
         let badgeColor = item.color || "#4A90D9";
         let badgePic = pic;
         let badgeInitial = initial;
-        if (item.shared && activeMember) {
+        if (!sharedMode && item.shared && activeMember) {
           badgeColor = activeColor;
           badgePic = activePic;
           badgeInitial = (activeMember || "?")[0];
@@ -538,12 +568,12 @@ class FamilyBoardChoresCard extends HTMLElement {
           ? `<img src="${this._escAttr(badgePic)}" alt="${this._esc(badgeInitial)}">`
           : this._esc(badgeInitial);
         const desc = item.description || "";
-        const sharedHtml = item.shared ? '<span class="shared-indicator">👥</span>' : '';
+        const sharedHtml = !sharedMode && item.shared ? '<span class="shared-indicator">👥</span>' : '';
 
         html += `
           <div class="${rowClass}" data-uid="${item.uid || ""}" style="--fb-color: ${this._escAttr(item.color || "#4A90D9")}">
             <div class="${checkboxClass}" data-uid="${item.uid || ""}" data-todo="${item.todo_entity || ""}"></div>
-            <div class="badge" style="background: ${this._escAttr(badgeColor)}">${badgeContent}</div>
+            ${sharedMode ? "" : `<div class="badge" style="background: ${this._escAttr(badgeColor)}">${badgeContent}</div>`}
             <div class="task-content">
               <div class="task-summary">${this._esc(item.summary || "")}${isActive ? '<span class="live-pill">NU</span>' : ''}${sharedHtml}</div>
               ${timeStr ? `<div class="${timeClass}">${overdue ? "⚠️ " : ""}${this._esc(timeStr)}</div>` : ""}
@@ -613,14 +643,33 @@ class FamilyBoardChoresCard extends HTMLElement {
   }
 }
 
-const CHORES_EDITOR_SCHEMA = [
-  { name: "entity", required: true, selector: { entity: { domain: "sensor" } } },
-  { name: "filter_entity", selector: { entity: { domain: "select" } } },
-  { name: "view_entity", selector: { entity: { domain: "select" } } },
-  { name: "members_entity", selector: { entity: { domain: "sensor" } } },
-  { name: "member", selector: { text: {} } },
-  { name: "show_header", selector: { boolean: {} } },
-];
+const SHARED_MEMBER_OPTION = { value: "shared", label: "Algemene (gedeeld)" };
+
+function buildChoresEditorSchema(hass, membersEntity) {
+  let memberSelector = { text: {} };
+  const stateObj = hass && membersEntity ? hass.states[membersEntity] : null;
+  const members = stateObj?.attributes?.members;
+  if (Array.isArray(members) && members.length) {
+    memberSelector = {
+      select: {
+        mode: "dropdown",
+        options: [
+          ...members.map((m) => ({ value: m.name, label: m.name })),
+          SHARED_MEMBER_OPTION,
+        ],
+      },
+    };
+  }
+  return [
+    { name: "entity", required: true, selector: { entity: { domain: "sensor" } } },
+    { name: "filter_entity", selector: { entity: { domain: "select" } } },
+    { name: "view_entity", selector: { entity: { domain: "select" } } },
+    { name: "members_entity", selector: { entity: { domain: "sensor" } } },
+    { name: "member", selector: memberSelector },
+    { name: "show_header", selector: { boolean: {} } },
+    { name: "show_shared", selector: { boolean: {} } },
+  ];
+}
 
 class FamilyBoardChoresCardEditor extends HTMLElement {
   constructor() {
@@ -645,7 +694,6 @@ class FamilyBoardChoresCardEditor extends HTMLElement {
     if (!this._form) {
       this._form = document.createElement("ha-form");
       this._form.computeLabel = (s) => s.label || s.name;
-      this._form.schema = CHORES_EDITOR_SCHEMA;
       this._form.addEventListener("value-changed", (ev) => {
         ev.stopPropagation();
         this.dispatchEvent(
@@ -659,6 +707,10 @@ class FamilyBoardChoresCardEditor extends HTMLElement {
       this.shadowRoot.appendChild(this._form);
     }
     if (this._hass) this._form.hass = this._hass;
+    this._form.schema = buildChoresEditorSchema(
+      this._hass,
+      this._config.members_entity || "sensor.familyboard_members",
+    );
     this._form.data = this._config;
   }
 }


### PR DESCRIPTION
## `familyboard-chores-card`: add `show_shared` option and shared-only mode

### Summary
Gives the chores card finer control over how shared ("algemene") chores are
rendered, and introduces a dedicated shared-only view so dashboards can split
personal and shared chores into separate cards.

### Changes
- **New `show_shared` option** (default `true`): when set to `false`, shared
  chores are hidden from the card. Applies to both an unbound card (no
  `member`) and a card bound to a specific `member`.
- **New `member: shared` value**: turns the card into a shared-only view.
  - Header renders as **"Algemene taken"** with a 👥 avatar and item count.
  - The `filter_entity` member chips and the `show_shared` toggle are ignored
    in this mode.
  - The `view_entity` (date window) still applies.
  - Per-row member badges and the inline 👥 indicator are suppressed — the
    header already conveys the context.
- **Editor improvements**: `member` is now a dropdown populated from the
  `members_entity` (`sensor.familyboard_members`), with an extra
  *"Algemene (gedeeld)"* entry. `show_shared` is exposed as a boolean toggle.
  Schema is rebuilt on render so it stays in sync with HA state.

### Docs
- README: documents `member: shared`, `show_shared`, and `show_header` options.
- CHANGELOG: entry under `## [Unreleased] / Added`.

### Files
- familyboard-chores-card.js
- README.md
- CHANGELOG.md

### Testing
Frontend-only change; no Python tests affected. Verify in the dev container:
1. Hard-reload the dashboard (`Ctrl+Shift+R`).
2. Add a chores card with `member: shared` → renders only shared chores under
   the "Algemene taken" header.
3. On a per-member card, set `show_shared: false` → personal chores only.
4. Open the card editor → `member` is a dropdown including
   *"Algemene (gedeeld)"*; `show_shared` toggle is present.